### PR TITLE
Fix AdminWeb restart handler payload usage

### DIFF
--- a/udp_bidirectional_main.py
+++ b/udp_bidirectional_main.py
@@ -6698,9 +6698,10 @@ class AdminWebUI:
             if auth != expected:
                 await self._send(writer, 403, b"Forbidden", "text/plain; charset=utf-8")
                 return
-        
+
+        payload = {"ok": True, "restarting": True}
         self._log_api_response("/api/restart", 200, payload)
-        await self._send_json(writer, 200, {"ok": True, "restarting": True})
+        await self._send_json(writer, 200, payload)
         self.runner.request_restart()
 
     async def _handle_shutdown(self, writer, method, headers):


### PR DESCRIPTION
### Motivation
- The Admin UI issues `POST /api/restart` but the backend raised a runtime exception by logging an undefined `payload` before it was created, preventing `request_restart()` from running.

### Description
- Define `payload = {"ok": True, "restarting": True}` in `AdminWebUI._handle_restart` and reuse it for both `self._log_api_response` and `self._send_json`, and tidy up trailing newline in `udp_bidirectional_main.py`.

### Testing
- Compiled the module with `python -m py_compile udp_bidirectional_main.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42c7c1f0883228cec7b1f35c682c7)