### PR TITLE
Add UDP per-connection counters, optional aioquic handling, and metrics checks in reconnect test

### DIFF
--- a/test_overlay_e2e_reconnect.py
+++ b/test_overlay_e2e_reconnect.py
@@ -526,6 +526,36 @@ def wait_admin_up(admin_port: int, timeout: float = 10.0) -> dict:
     raise RuntimeError(f'Admin endpoint not ready on port {admin_port}: {last_exc}')
 
 
+def _conn_rows_with_traffic(doc: dict) -> list[dict]:
+    rows = []
+    for key in ('udp', 'tcp'):
+        for row in doc.get(key, []) or []:
+            stats = row.get('stats') or {}
+            if (
+                int(stats.get('rx_msgs', 0)) > 0
+                and int(stats.get('tx_msgs', 0)) > 0
+                and int(stats.get('rx_bytes', 0)) > 0
+                and int(stats.get('tx_bytes', 0)) > 0
+            ):
+                rows.append(row)
+    return rows
+
+
+def wait_connections_metrics_updated(admin_port: int, timeout: float = 8.0, label: str = '') -> dict:
+    end = time.time() + timeout
+    last_doc = None
+    while time.time() < end:
+        _code, doc = fetch_json(f'http://127.0.0.1:{admin_port}/api/connections', timeout=1.5)
+        last_doc = doc
+        rows = _conn_rows_with_traffic(doc)
+        if rows:
+            who = f' {label}' if label else ''
+            log.info(f'[METRICS]{who} port={admin_port} traffic rows={len(rows)}')
+            return doc
+        time.sleep(0.25)
+    raise RuntimeError(f'/api/connections metrics not updated on port {admin_port}; last={last_doc!r}')
+
+
 def status_state(doc: dict) -> str:
     return str(doc.get('peer_state', '')).strip().upper()
 
@@ -780,8 +810,12 @@ def run_case_reconnect(case: Case, log_dir: Path, case_index: int, settle_s: Opt
             )
 
         phase('12. Send probe 01 34 and expect 02 34')
-        log.info('[PROBE] send=0134 expect=0234')        
+        log.info('[PROBE] send=0134 expect=0234')
         wait_probe(case, payload=b'\x01\x34', timeout=8.0)
+
+        phase('13. Verify per-connection metrics updated after 01 34 / 02 34 exchange')
+        wait_connections_metrics_updated(server_proc.admin_port or 0, timeout=8.0, label='server')
+        wait_connections_metrics_updated(client_proc.admin_port or 0, timeout=8.0, label='client')
     finally:
         if client_proc is not None:
             stop_proc(client_proc)

--- a/udp_bidirectional_main.py
+++ b/udp_bidirectional_main.py
@@ -2928,14 +2928,39 @@ import time
 import logging
 from typing import Optional, Callable, Tuple
 
-from aioquic.asyncio import serve as quic_serve, connect as quic_connect, QuicConnectionProtocol
-from aioquic.quic.configuration import QuicConfiguration
-from aioquic.quic.events import (
-    StreamDataReceived,
-    HandshakeCompleted,
-    ConnectionTerminated,
-    ProtocolNegotiated,
-)
+try:
+    from aioquic.asyncio import serve as quic_serve, connect as quic_connect, QuicConnectionProtocol
+    from aioquic.quic.configuration import QuicConfiguration
+    from aioquic.quic.events import (
+        StreamDataReceived,
+        HandshakeCompleted,
+        ConnectionTerminated,
+        ProtocolNegotiated,
+    )
+    _AIOQUIC_IMPORT_ERROR: Optional[Exception] = None
+except Exception as _aioquic_import_err:
+    quic_serve = None
+    quic_connect = None
+
+    class QuicConnectionProtocol:  # type: ignore[no-redef]
+        pass
+
+    class QuicConfiguration:  # type: ignore[no-redef]
+        pass
+
+    class StreamDataReceived:  # type: ignore[no-redef]
+        pass
+
+    class HandshakeCompleted:  # type: ignore[no-redef]
+        pass
+
+    class ConnectionTerminated:  # type: ignore[no-redef]
+        pass
+
+    class ProtocolNegotiated:  # type: ignore[no-redef]
+        pass
+
+    _AIOQUIC_IMPORT_ERROR = _aioquic_import_err
 
 class QuicSession(ISession):
     """
@@ -2988,6 +3013,12 @@ class QuicSession(ISession):
         return QuicSession(args)
 
     def __init__(self, args: argparse.Namespace):
+        if _AIOQUIC_IMPORT_ERROR is not None:
+            raise RuntimeError(
+                "overlay_transport=quic requires optional dependency 'aioquic'. "
+                "Install it with: pip install aioquic"
+            ) from _AIOQUIC_IMPORT_ERROR
+
         import zlib as _z
         self._args = args
         self._log  = logging.getLogger("quic_session")
@@ -5036,6 +5067,8 @@ class ChannelMux:
             srv_tr = self._svc_udp_servers.get(svc_id)
             if srv_tr:
                 try:
+                    ctr.msgs_out += 1
+                    ctr.bytes_out += len(data)
                     srv_tr.sendto(data, addr)
                     # Touch activity
                     key = (svc_id, addr)
@@ -5070,6 +5103,8 @@ class ChannelMux:
 
         # We have a transport: send and log
         try:
+            ctr.msgs_out += 1
+            ctr.bytes_out += len(data)
             tr.sendto(data)
             self._udp_client_last_ts[chan] = time.time()
         except Exception as e:
@@ -5690,10 +5725,10 @@ class ChannelMux:
                 "tx_bytes": 0,
             }
         return {
-            "rx_msgs": int(getattr(c, "rx_msgs", 0)),
-            "tx_msgs": int(getattr(c, "tx_msgs", 0)),
-            "rx_bytes": int(getattr(c, "rx_bytes", 0)),
-            "tx_bytes": int(getattr(c, "tx_bytes", 0)),
+            "rx_msgs": int(getattr(c, "msgs_in", 0)),
+            "tx_msgs": int(getattr(c, "msgs_out", 0)),
+            "rx_bytes": int(getattr(c, "bytes_in", 0)),
+            "tx_bytes": int(getattr(c, "bytes_out", 0)),
         }
 
     def snapshot_udp_connections(self) -> list[dict]:


### PR DESCRIPTION
### Motivation
- Ensure per-connection UDP statistics reflect messages and bytes actually sent so connection metrics are accurate.
- Make the QUIC overlay dependency failure clearer by detecting missing `aioquic` at import time and surfacing a helpful error.
- Improve the reconnect end-to-end test by waiting for per-connection metrics to be updated after probe exchanges.

### Description
- Increment per-channel transmit counters (`msgs_out`/`bytes_out`) in `ChannelMux._rx_udp_data` for both server and client send paths so `snapshot_udp_connections` reports correct tx metrics. 
- Remap `_chan_stat_dict` to return `rx_msgs/tx_msgs/rx_bytes/tx_bytes` from the underlying `msgs_in/msgs_out/bytes_in/bytes_out` attributes. 
- Wrap `aioquic` imports in a `try/except`, provide placeholder classes and `_AIOQUIC_IMPORT_ERROR`, and raise a clear `RuntimeError` in `QuicSession.__init__` if `aioquic` is not installed. 
- Add helpers `_conn_rows_with_traffic` and `wait_connections_metrics_updated` to `test_overlay_e2e_reconnect.py` and call them from the reconnect scenario to assert that `/api/connections` shows non-zero rx/tx msgs and bytes for UDP/TCP after a probe exchange. 

### Testing
- Ran the reconnect e2e test in `test_overlay_e2e_reconnect.py` (relevant case that performs the 01/02 probe exchanges) and it completed successfully. 
- Ran the project's test suite with `pytest -q` to validate the change and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48f932a0c83228549e648143341d7)