### PR TITLE
Add --ws-payload-mode to support base64-encoded WebSocket payloads

### DIFF
--- a/test_ws_payload_mode.py
+++ b/test_ws_payload_mode.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import argparse
+import unittest
+
+from udp_bidirectional_main import WebSocketSession
+
+
+def _args(ws_payload_mode: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        bind443="0.0.0.0",
+        port443=0,
+        peer=None,
+        peer_port=0,
+        ws_path="/",
+        ws_subprotocol=None,
+        ws_tls=False,
+        ws_max_size=65535,
+        ws_payload_mode=ws_payload_mode,
+        ws_static_dir="",
+    )
+
+
+class WebSocketPayloadModeTests(unittest.TestCase):
+    def test_binary_mode_keeps_bytes_on_send(self):
+        session = WebSocketSession(_args("binary"))
+        wire = b"\x00hello"
+        self.assertEqual(session._encode_ws_message(wire), wire)
+
+    def test_base64_mode_encodes_and_decodes_text_frames(self):
+        session = WebSocketSession(_args("base64"))
+        wire = b"\x01hello\x00world"
+        encoded = session._encode_ws_message(wire)
+        self.assertIsInstance(encoded, str)
+        self.assertEqual(session._decode_ws_message(encoded), wire)
+
+    def test_text_frames_must_be_valid_base64(self):
+        session = WebSocketSession(_args("binary"))
+        self.assertIsNone(session._decode_ws_message("not base64 !!!"))
+
+    def test_binary_frames_are_still_accepted_in_base64_mode(self):
+        session = WebSocketSession(_args("base64"))
+        wire = b"\x02pong"
+        self.assertEqual(session._decode_ws_message(wire), wire)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/udp_bidirectional_main.py
+++ b/udp_bidirectional_main.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import enum
 import importlib.util
 import ipaddress
@@ -3673,7 +3674,7 @@ class QuicSession(ISession):
 # Requires: pip install websockets
 class WebSocketSession(ISession):
     """
-    Overlay over one WebSocket (binary messages):
+    Overlay over one WebSocket (binary messages by default, optional base64 text frames):
       wire := KIND(1) + BYTES...
       KIND=0x00 -> APP (to upper layer)
       KIND=0x01 -> PING (payload: Q tx_ns, Q echo_ns)
@@ -3710,6 +3711,13 @@ class WebSocketSession(ISession):
         if not _has('--ws-max-size'):
             p.add_argument('--ws-max-size', type=int, default=65535,
                            help='Maximum binary message size to accept/send (default 65535).')
+        if not _has('--ws-payload-mode'):
+            p.add_argument(
+                '--ws-payload-mode',
+                choices=['binary', 'base64'],
+                default='binary',
+                help='WebSocket payload transfer mode: raw binary frames (default) or base64-encoded text frames.'
+            )
         if not _has('--ws-static-dir'):
             p.add_argument(
                 '--ws-static-dir',
@@ -3748,6 +3756,7 @@ class WebSocketSession(ISession):
         self._ws_subprotocol: Optional[str] = getattr(self._args, "ws_subprotocol", None)
         self._use_tls: bool = bool(getattr(self._args, "ws_tls", False))
         self._ws_max_size: int = int(getattr(self._args, "ws_max_size", 65535))
+        self._ws_payload_mode: str = str(getattr(self._args, "ws_payload_mode", "binary") or "binary").lower()
 
         # Runtime
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -4302,10 +4311,26 @@ class WebSocketSession(ISession):
             return
         async def _send():
             try:
-                await self._ws.send(wire)  # binary
+                await self._ws.send(self._encode_ws_message(wire))
             except Exception as e:
                 self._log.info(f"[WS/TX] ({self._probe_id}) send error: {e!r}")
         self._loop.create_task(_send())  # type: ignore
+
+    def _encode_ws_message(self, wire: bytes):
+        if self._ws_payload_mode == "base64":
+            return base64.b64encode(wire).decode("ascii")
+        return wire
+
+    def _decode_ws_message(self, msg) -> Optional[bytes]:
+        if isinstance(msg, (bytes, bytearray)):
+            return bytes(msg)
+        if isinstance(msg, str):
+            try:
+                return base64.b64decode(msg.encode("ascii"), validate=True)
+            except Exception as e:
+                self._log.debug(f"[WS/RX] ({self._probe_id}) invalid base64 text frame: {e!r}")
+                return None
+        return None
 
     def _send_ping_frame(self, ping_payload: bytes) -> None:
         """
@@ -4357,9 +4382,9 @@ class WebSocketSession(ISession):
         try:
             while True:
                 msg = await self._ws.recv()  # type: ignore
-                if not isinstance(msg, (bytes, bytearray)):
-                    continue  # ignore text frames
-                b = bytes(msg)
+                b = self._decode_ws_message(msg)
+                if b is None:
+                    continue
                 if not b:
                     continue
 


### PR DESCRIPTION
### Motivation
- Provide an option to transport the overlay `KIND+payload` wire over WebSocket as base64 text frames instead of raw binary frames for environments that require or prefer text frames.

### Description
- Added a new CLI flag `--ws-payload-mode` (choices: `binary`, `base64`) to `WebSocketSession.register_cli` and stored the choice in `self._ws_payload_mode` on session init.
- Implemented `_encode_ws_message` and `_decode_ws_message` helpers and updated send/receive paths so outgoing frames are base64-encoded text when `base64` is selected while incoming messages accept raw binary or valid base64 text frames.
- Kept internal overlay wire format unchanged (`KIND + payload`); only transport framing/type changes depending on selected mode and decoding errors are logged and ignored.
- Added unit tests `test_ws_payload_mode.py` that cover binary-mode pass-through, base64 round-trip encoding/decoding, invalid base64 rejection, and acceptance of binary frames in base64 mode.

### Testing
- Ran unit tests with `python -m unittest test_ws_payload_mode.py`, which executed 4 tests and all passed (`OK`).
- Performed static compilation checks with `python -m py_compile udp_bidirectional_main.py test_ws_payload_mode.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd0488490832297efe0ac211b66a8)