### PR TITLE
Disable WebSocket compression for overlay traffic

### DIFF
--- a/test_ws_payload_mode.py
+++ b/test_ws_payload_mode.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import argparse
+import asyncio
+import sys
+import types
 import unittest
 from unittest import mock
 
@@ -136,6 +139,61 @@ class WebSocketHttpPreflightTests(unittest.IsolatedAsyncioTestCase):
         with mock.patch("udp_bidirectional_main.asyncio.open_connection", mock.AsyncMock(return_value=(reader, writer))):
             with self.assertRaisesRegex(RuntimeError, "unexpected HTTP status 404"):
                 await session._load_default_http_page(host="127.0.0.1", port=54321)
+
+
+class WebSocketCompressionConfigTests(unittest.IsolatedAsyncioTestCase):
+    async def test_start_server_disables_websocket_compression(self):
+        session = WebSocketSession(_args("binary"))
+        session._loop = asyncio.get_running_loop()
+        session._run_flag = True
+
+        fake_server = types.SimpleNamespace(
+            sockets=[types.SimpleNamespace(getsockname=lambda: ("127.0.0.1", 54321))]
+        )
+        serve = mock.AsyncMock(return_value=fake_server)
+        fake_websockets = types.SimpleNamespace(serve=serve)
+        fake_http11 = types.SimpleNamespace(Response=object)
+        fake_ds = types.SimpleNamespace(Headers=lambda items: items)
+
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "websockets": fake_websockets,
+                "websockets.http11": fake_http11,
+                "websockets.datastructures": fake_ds,
+            },
+        ):
+            await session._start_server()
+
+        self.assertIs(session._server, fake_server)
+        self.assertEqual(serve.await_args.kwargs["compression"], None)
+
+    async def test_connect_disables_websocket_compression(self):
+        args = _args("binary")
+        args.peer = "127.0.0.1"
+        args.peer_port = 54321
+        session = WebSocketSession(args)
+        session._loop = asyncio.get_running_loop()
+        session._run_flag = True
+        session._peer_tuple = ("127.0.0.1", 54321)
+        session._peer_name_host = "overlay.example"
+        session._peer_name_port = 54321
+
+        fake_ws = types.SimpleNamespace(
+            local_address=("127.0.0.1", 40000),
+            remote_address=("127.0.0.1", 54321),
+        )
+        connect = mock.AsyncMock(return_value=fake_ws)
+        fake_websockets = types.SimpleNamespace(connect=connect)
+
+        with mock.patch.dict(sys.modules, {"websockets": fake_websockets}):
+            with mock.patch.object(session, "_load_default_http_page", mock.AsyncMock()) as preflight:
+                with mock.patch.object(session, "_on_accept", mock.AsyncMock()) as on_accept:
+                    await session._connect_to("127.0.0.1", 54321)
+
+        preflight.assert_awaited_once()
+        on_accept.assert_awaited_once_with(fake_ws)
+        self.assertEqual(connect.await_args.kwargs["compression"], None)
 
 
 if __name__ == "__main__":

--- a/udp_bidirectional_main.py
+++ b/udp_bidirectional_main.py
@@ -3822,6 +3822,9 @@ class WebSocketSession(ISession):
         if codec_cls is None:
             raise ValueError(f"Unsupported --ws-payload-mode: {self._ws_payload_mode}")
         self._ws_payload_codec: WebSocketPayloadCodec = codec_cls()
+        # Reverse proxies can negotiate permessage-deflate but then stall or drop
+        # tiny control messages. Keep overlay framing simple and deterministic.
+        self._ws_compression = None
 
         # Runtime
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -4194,6 +4197,7 @@ class WebSocketSession(ISession):
             ssl=ssl_ctx,
             subprotocols=subprotocols,
             max_size=self._ws_max_size,
+            compression=self._ws_compression,
             ping_interval=None,  # we run our own RTT ping
             ping_timeout=None,
             process_request=_process_request,  # <-- key: serve static before WS
@@ -4308,6 +4312,7 @@ class WebSocketSession(ISession):
                 ssl=ssl_ctx,
                 subprotocols=subprotocols,
                 max_size=self._ws_max_size,
+                compression=self._ws_compression,
                 ping_interval=None,    # we run our own RTT ping
                 ping_timeout=None,
                 **connect_kwargs,


### PR DESCRIPTION
### Motivation
- Reverse proxies can negotiate `permessage-deflate` and occasionally stall or drop very small control frames (RTT PING/PONG), causing the overlay to flip disconnected unexpectedly.
- The overlay uses its own RTT/keepalive framing and should avoid compressed frames to keep control messages deterministic and reliable.

### Description
- Add a per-session `self._ws_compression = None` and pass `compression=self._ws_compression` to both `websockets.serve(...)` and `websockets.connect(...)` to disable permessage-deflate for overlay server and client paths in `udp_bidirectional_main.py`.
- Document rationale in a short comment where the option is set so the choice is explicit and discoverable.
- Add `WebSocketCompressionConfigTests` in `test_ws_payload_mode.py` that mock `websockets.serve` and `websockets.connect` and assert they are called with `compression=None` to prevent regressions.
- Add small test scaffolding imports (`asyncio`, `sys`, `types`) required by the new tests.

### Testing
- Ran `python -m unittest test_ws_payload_mode.py`, all tests passed (10 tests, OK).
- Ran `python -m py_compile udp_bidirectional_main.py test_ws_payload_mode.py` to verify syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc48835df8832294bfe6d2a4003f53)