### PR TITLE
Mitigate stalled WebSocket sends by adding send timeout and post-send accounting

### DIFF
--- a/test_ws_payload_mode.py
+++ b/test_ws_payload_mode.py
@@ -62,6 +62,24 @@ class _FakeWriter:
         self.wait_closed_called = True
 
 
+
+
+class _FakeWs:
+    def __init__(self):
+        self.sent = []
+        self.close_calls = 0
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def close(self):
+        self.close_calls += 1
+
+
+class _HangingWs(_FakeWs):
+    async def send(self, payload):
+        await asyncio.Future()
+
 class WebSocketPayloadModeTests(unittest.TestCase):
     def test_binary_mode_keeps_bytes_on_send(self):
         session = WebSocketSession(_args("binary"))
@@ -106,6 +124,43 @@ class WebSocketPayloadModeTests(unittest.TestCase):
         self.assertEqual(sent, [b"\x01first", b"\x02second"])
         self.assertEqual(len(session._early_buf), 0)
         self.assertEqual(session._early_buf_bytes, 0)
+
+
+class WebSocketTxLoopTests(unittest.IsolatedAsyncioTestCase):
+    async def test_tx_accounting_happens_after_successful_send(self):
+        session = WebSocketSession(_args("binary"))
+        session._loop = asyncio.get_running_loop()
+        session._ws = _FakeWs()
+        sent_sizes = []
+        session.set_on_peer_tx(sent_sizes.append)
+
+        session.send_app(b"hello")
+        await asyncio.wait_for(session._tx_queue.join(), timeout=1.0)
+
+        self.assertEqual(session._tx_bytes, 6)
+        self.assertEqual(sent_sizes, [6])
+        self.assertEqual(session._ws.sent, [b"\x00hello"])
+
+        session._tx_task.cancel()
+        await session._tx_task
+
+    async def test_tx_timeout_forces_websocket_close(self):
+        args = _args("binary")
+        args.ws_send_timeout = 0.01
+        session = WebSocketSession(args)
+        session._loop = asyncio.get_running_loop()
+        hanging = _HangingWs()
+        session._ws = hanging
+
+        session.send_app(b"hello")
+        await asyncio.sleep(0.05)
+        await asyncio.wait_for(session._tx_queue.join(), timeout=1.0)
+
+        self.assertEqual(session._tx_bytes, 0)
+        self.assertEqual(hanging.close_calls, 1)
+
+        session._tx_task.cancel()
+        await session._tx_task
 
 
 class WebSocketHttpPreflightTests(unittest.IsolatedAsyncioTestCase):

--- a/udp_bidirectional_main.py
+++ b/udp_bidirectional_main.py
@@ -3786,6 +3786,13 @@ class WebSocketSession(ISession):
                 help="Directory to serve as a static web root on the WS port (default ./web). "
                     "Set to '' to disable."
         )
+        if not _has('--ws-send-timeout'):
+            p.add_argument(
+                '--ws-send-timeout',
+                type=float,
+                default=3.0,
+                help='Seconds to wait for a WebSocket frame send before forcing reconnect (default 3.0).',
+            )
 
 
     @staticmethod
@@ -3822,6 +3829,7 @@ class WebSocketSession(ISession):
         if codec_cls is None:
             raise ValueError(f"Unsupported --ws-payload-mode: {self._ws_payload_mode}")
         self._ws_payload_codec: WebSocketPayloadCodec = codec_cls()
+        self._ws_send_timeout_s: float = max(0.0, float(getattr(self._args, "ws_send_timeout", 3.0) or 0.0))
         # Reverse proxies can negotiate permessage-deflate but then stall or drop
         # tiny control messages. Keep overlay framing simple and deterministic.
         self._ws_compression = None
@@ -3837,7 +3845,7 @@ class WebSocketSession(ISession):
         self._tx_task: Optional[asyncio.Task] = None
         self._connecting_task: Optional[asyncio.Task] = None
         self._reconnect_task: Optional[asyncio.Task] = None
-        self._tx_queue: "asyncio.Queue[bytes]" = asyncio.Queue()
+        self._tx_queue: "asyncio.Queue[tuple[bytes, Optional[Callable[[], None]]]]" = asyncio.Queue()
 
         # Early buffer (APP/CTRL frames preserved as individual WS messages)
         self._early_buf: Deque[bytes] = deque()
@@ -3961,11 +3969,7 @@ class WebSocketSession(ISession):
                 self._ensure_connect_once()
             return len(payload)
 
-        self._schedule_send(wire)
-        self._bump_tx(wire)
-        if self._on_peer_tx:
-            try: self._on_peer_tx(len(wire))
-            except Exception: pass
+        self._schedule_send(wire, on_sent=lambda: self._notify_peer_tx(len(wire)))
         return len(payload)
 
     # ---- Internals ------------------------------------------------------------
@@ -4385,7 +4389,6 @@ class WebSocketSession(ISession):
             )
             for wire in pending:
                 self._schedule_send(wire)
-                self._bump_tx(wire)
         except Exception as e:
             self._log.info(f"[WS/TX] ({self._probe_id}) flush error: {e!r}")
         finally:
@@ -4401,11 +4404,29 @@ class WebSocketSession(ISession):
         async def _tx_loop():
             try:
                 while True:
-                    wire = await self._tx_queue.get()
+                    wire, on_sent = await self._tx_queue.get()
                     try:
                         if not self._ws:
                             continue
-                        await self._ws.send(self._ws_payload_codec.encode(wire))
+                        send_coro = self._ws.send(self._ws_payload_codec.encode(wire))
+                        if self._ws_send_timeout_s > 0:
+                            await asyncio.wait_for(send_coro, timeout=self._ws_send_timeout_s)
+                        else:
+                            await send_coro
+                        self._bump_tx(wire)
+                        if callable(on_sent):
+                            try:
+                                on_sent()
+                            except Exception:
+                                pass
+                    except asyncio.TimeoutError:
+                        self._log.warning(
+                            f"[WS/TX] ({self._probe_id}) send timeout after {self._ws_send_timeout_s:.3f}s; forcing reconnect"
+                        )
+                        try:
+                            await asyncio.wait_for(self._ws.close(), timeout=1.0)
+                        except Exception:
+                            pass
                     except Exception as e:
                         self._log.info(f"[WS/TX] ({self._probe_id}) send error: {e!r}")
                     finally:
@@ -4415,11 +4436,19 @@ class WebSocketSession(ISession):
 
         self._tx_task = self._loop.create_task(_tx_loop())  # type: ignore
 
-    def _schedule_send(self, wire: bytes) -> None:
+    def _schedule_send(self, wire: bytes, on_sent: Optional[Callable[[], None]] = None) -> None:
         if not self._ws:
             return
         self._ensure_tx_task()
-        self._tx_queue.put_nowait(bytes(wire))
+        self._tx_queue.put_nowait((bytes(wire), on_sent))
+
+
+    def _notify_peer_tx(self, nbytes: int) -> None:
+        if self._on_peer_tx:
+            try:
+                self._on_peer_tx(nbytes)
+            except Exception:
+                pass
 
     def _decode_ws_message(self, msg) -> Optional[bytes]:
         if isinstance(msg, str):
@@ -4562,14 +4591,8 @@ class WebSocketSession(ISession):
         except Exception:
             pass
 
-        self._schedule_send(body)
-        self._bump_tx(body)
-        if self._on_peer_tx:
-            try:
-                self._on_peer_tx(len(body))
-            except Exception:
-                pass
-        self._log.debug(f"[WS/TX] ({self._probe_id}) PING")
+        self._schedule_send(body, on_sent=lambda: self._notify_peer_tx(len(body)))
+        self._log.debug(f"[WS/TX] ({self._probe_id}) PING queued")
             
     def _send_pong_frame(self, echo_tx_ns: int) -> None:
         if not self._ws:
@@ -4580,14 +4603,8 @@ class WebSocketSession(ISession):
         # Guard log
         self._log.debug(f"[WS/GUARD] ({self._probe_id}) PONG tx: echo_tx_ns={echo_tx_ns}")
 
-        self._schedule_send(body)
-        self._bump_tx(body)
-        if self._on_peer_tx:
-            try:
-                self._on_peer_tx(len(body))
-            except Exception:
-                pass
-        self._log.debug(f"[WS/TX] ({self._probe_id}) PONG")
+        self._schedule_send(body, on_sent=lambda: self._notify_peer_tx(len(body)))
+        self._log.debug(f"[WS/TX] ({self._probe_id}) PONG queued")
 
     # --- RX pump ---------------------------------------------------------------
     async def _rx_pump(self) -> None:


### PR DESCRIPTION
### Motivation
- Observed logs showed many PINGs being "sent" while the PCAP showed only the first frames left the host, indicating queued writes on a stalled WebSocket rather than real wire activity. 
- The change aims to make TX accounting match bytes that actually left user space and to recover from a stuck `ws.send()` by forcing a reconnect.

### Description
- Add a configurable CLI option `--ws-send-timeout` (default `3.0s`) and store it in `WebSocketSession._ws_send_timeout_s` to bound how long the TX loop waits for `ws.send()`.
- Change the TX queue to carry items `(wire, on_sent)` and update `_schedule_send` to accept an optional `on_sent` callback so accounting/callbacks run only after a successful send.
- Update the TX loop to `await` the underlying `ws.send(...)` with `asyncio.wait_for(..., timeout=_ws_send_timeout_s)`, call `_bump_tx()` and the `on_sent` callback only after send completion, and forcibly close the WebSocket on a send timeout to trigger reconnect.
- Adjust early-flush and `PING`/`PONG` send paths to queue frames (log as `queued`) and invoke peer-TX callbacks only after actual sends; add `_notify_peer_tx` helper and unit tests covering successful accounting and forced close on timeout (`test_ws_payload_mode.py`).

### Testing
- Ran static syntax check with `python -m py_compile udp_bidirectional_main.py test_ws_payload_mode.py` and it succeeded.
- Ran unit tests with `python -m unittest test_ws_payload_mode.py` and the new/updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd52dbe5e483229ebb00525ee085d4)