### PR TITLE
WebSocket: send timeout, TCP_USER_TIMEOUT, reconnect grace, reliable TX accounting and socket options

### DIFF
--- a/test_ws_payload_mode.py
+++ b/test_ws_payload_mode.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import asyncio
+import socket
 import sys
 import types
 import unittest
@@ -21,6 +22,9 @@ def _args(ws_payload_mode: str) -> argparse.Namespace:
         ws_max_size=65535,
         ws_payload_mode=ws_payload_mode,
         ws_static_dir="",
+        ws_send_timeout=3.0,
+        ws_tcp_user_timeout_ms=10000,
+        ws_reconnect_grace=3.0,
     )
 
 
@@ -61,6 +65,54 @@ class _FakeWriter:
     async def wait_closed(self):
         self.wait_closed_called = True
 
+
+
+
+class _FakeWs:
+    def __init__(self):
+        self.sent = []
+        self.close_calls = 0
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def close(self):
+        self.close_calls += 1
+
+    async def recv(self):
+        await asyncio.Future()
+
+    async def wait_closed(self):
+        return None
+
+
+class _HangingWs(_FakeWs):
+    async def send(self, payload):
+        await asyncio.Future()
+
+
+class _FakeSocket:
+    def __init__(self):
+        self.calls = []
+
+    def setsockopt(self, level, optname, value):
+        self.calls.append((level, optname, value))
+
+
+class _FakeTransport:
+    def __init__(self, sock):
+        self._sock = sock
+
+    def get_extra_info(self, name):
+        if name == "socket":
+            return self._sock
+        return None
+
+
+class _SockoptWs(_FakeWs):
+    def __init__(self, sock):
+        super().__init__()
+        self.transport = _FakeTransport(sock)
 
 class WebSocketPayloadModeTests(unittest.TestCase):
     def test_binary_mode_keeps_bytes_on_send(self):
@@ -106,6 +158,99 @@ class WebSocketPayloadModeTests(unittest.TestCase):
         self.assertEqual(sent, [b"\x01first", b"\x02second"])
         self.assertEqual(len(session._early_buf), 0)
         self.assertEqual(session._early_buf_bytes, 0)
+
+
+class WebSocketTxLoopTests(unittest.IsolatedAsyncioTestCase):
+    async def test_tx_accounting_happens_after_successful_send(self):
+        session = WebSocketSession(_args("binary"))
+        session._loop = asyncio.get_running_loop()
+        session._ws = _FakeWs()
+        sent_sizes = []
+        session.set_on_peer_tx(sent_sizes.append)
+
+        session.send_app(b"hello")
+        await asyncio.wait_for(session._tx_queue.join(), timeout=1.0)
+
+        self.assertEqual(session._tx_bytes, 6)
+        self.assertEqual(sent_sizes, [6])
+        self.assertEqual(session._ws.sent, [b"\x00hello"])
+
+        session._tx_task.cancel()
+        await session._tx_task
+
+    async def test_tx_timeout_forces_websocket_close(self):
+        args = _args("binary")
+        args.ws_send_timeout = 0.01
+        session = WebSocketSession(args)
+        session._loop = asyncio.get_running_loop()
+        hanging = _HangingWs()
+        session._ws = hanging
+
+        session.send_app(b"hello")
+        await asyncio.sleep(0.05)
+        await asyncio.wait_for(session._tx_queue.join(), timeout=1.0)
+
+        self.assertEqual(session._tx_bytes, 0)
+        self.assertEqual(hanging.close_calls, 1)
+
+        session._tx_task.cancel()
+        await session._tx_task
+
+
+class WebSocketSocketConfigTests(unittest.TestCase):
+    def test_configure_ws_socket_sets_keepalive_and_tcp_user_timeout(self):
+        session = WebSocketSession(_args("binary"))
+        sock = _FakeSocket()
+        session._configure_ws_socket(_SockoptWs(sock))
+
+        self.assertIn((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1), sock.calls)
+        tcp_user_timeout = getattr(socket, "TCP_USER_TIMEOUT", None)
+        if tcp_user_timeout is not None:
+            self.assertIn((socket.IPPROTO_TCP, tcp_user_timeout, 10000), sock.calls)
+
+    def test_configure_ws_socket_skips_missing_socket(self):
+        session = WebSocketSession(_args("binary"))
+        ws = type("NoSockWs", (), {"transport": None})()
+        session._configure_ws_socket(ws)
+
+
+class WebSocketReconnectGraceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_quick_reconnect_cancels_pending_disconnect(self):
+        args = _args("binary")
+        args.ws_reconnect_grace = 0.05
+        session = WebSocketSession(args)
+        session._loop = asyncio.get_running_loop()
+        session._run_flag = True
+        session._overlay_connected = True
+        session._schedule_overlay_disconnect()
+
+        self.assertIsNotNone(session._disconnect_task)
+
+        session._ws = object()
+        await session._on_accept(_SockoptWs(_FakeSocket()))
+        await asyncio.sleep(0.08)
+
+        self.assertTrue(session._overlay_connected)
+        self.assertIsNone(session._disconnect_task)
+
+        session._rx_task.cancel()
+        await session._rx_task
+        session._tx_task.cancel()
+        await session._tx_task
+
+    async def test_disconnect_fires_after_grace_when_not_reconnected(self):
+        args = _args("binary")
+        args.ws_reconnect_grace = 0.05
+        session = WebSocketSession(args)
+        session._loop = asyncio.get_running_loop()
+        session._run_flag = True
+        session._overlay_connected = True
+        session._schedule_overlay_disconnect()
+
+        await asyncio.sleep(0.08)
+
+        self.assertFalse(session._overlay_connected)
+        self.assertIsNone(session._disconnect_task)
 
 
 class WebSocketHttpPreflightTests(unittest.IsolatedAsyncioTestCase):

--- a/udp_bidirectional_main.py
+++ b/udp_bidirectional_main.py
@@ -3786,6 +3786,27 @@ class WebSocketSession(ISession):
                 help="Directory to serve as a static web root on the WS port (default ./web). "
                     "Set to '' to disable."
         )
+        if not _has('--ws-send-timeout'):
+            p.add_argument(
+                '--ws-send-timeout',
+                type=float,
+                default=3.0,
+                help='Seconds to wait for a WebSocket frame send before forcing reconnect (default 3.0).',
+            )
+        if not _has('--ws-tcp-user-timeout-ms'):
+            p.add_argument(
+                '--ws-tcp-user-timeout-ms',
+                type=int,
+                default=10000,
+                help='TCP_USER_TIMEOUT in milliseconds for WebSocket sockets (default 10000, 0 disables).',
+            )
+        if not _has('--ws-reconnect-grace'):
+            p.add_argument(
+                '--ws-reconnect-grace',
+                type=float,
+                default=3.0,
+                help='Seconds to wait before reporting DISCONNECTED after WS transport loss (default 3.0).',
+            )
 
 
     @staticmethod
@@ -3822,6 +3843,9 @@ class WebSocketSession(ISession):
         if codec_cls is None:
             raise ValueError(f"Unsupported --ws-payload-mode: {self._ws_payload_mode}")
         self._ws_payload_codec: WebSocketPayloadCodec = codec_cls()
+        self._ws_send_timeout_s: float = max(0.0, float(getattr(self._args, "ws_send_timeout", 3.0) or 0.0))
+        self._ws_tcp_user_timeout_ms: int = max(0, int(getattr(self._args, "ws_tcp_user_timeout_ms", 10000) or 0))
+        self._ws_reconnect_grace_s: float = max(0.0, float(getattr(self._args, "ws_reconnect_grace", 3.0) or 0.0))
         # Reverse proxies can negotiate permessage-deflate but then stall or drop
         # tiny control messages. Keep overlay framing simple and deterministic.
         self._ws_compression = None
@@ -3837,7 +3861,8 @@ class WebSocketSession(ISession):
         self._tx_task: Optional[asyncio.Task] = None
         self._connecting_task: Optional[asyncio.Task] = None
         self._reconnect_task: Optional[asyncio.Task] = None
-        self._tx_queue: "asyncio.Queue[bytes]" = asyncio.Queue()
+        self._disconnect_task: Optional[asyncio.Task] = None
+        self._tx_queue: "asyncio.Queue[tuple[bytes, Optional[Callable[[], None]]]]" = asyncio.Queue()
 
         # Early buffer (APP/CTRL frames preserved as individual WS messages)
         self._early_buf: Deque[bytes] = deque()
@@ -3904,6 +3929,9 @@ class WebSocketSession(ISession):
             if t: t.cancel()
         self._connecting_task = None
         self._reconnect_task = None
+        if self._disconnect_task:
+            self._disconnect_task.cancel()
+            self._disconnect_task = None
 
         for attr in ("_rx_task", "_tx_task"):
             try:
@@ -3961,11 +3989,7 @@ class WebSocketSession(ISession):
                 self._ensure_connect_once()
             return len(payload)
 
-        self._schedule_send(wire)
-        self._bump_tx(wire)
-        if self._on_peer_tx:
-            try: self._on_peer_tx(len(wire))
-            except Exception: pass
+        self._schedule_send(wire, on_sent=lambda: self._notify_peer_tx(len(wire)))
         return len(payload)
 
     # ---- Internals ------------------------------------------------------------
@@ -4244,6 +4268,10 @@ class WebSocketSession(ISession):
             pass
 
         self._ws = ws
+        if self._disconnect_task:
+            self._disconnect_task.cancel()
+            self._disconnect_task = None
+        self._configure_ws_socket(ws)
         peer = getattr(ws, "remote_address", None)
         sockname = getattr(ws, "local_address", None)
         self._log.info(f"[WS-SESSION] ({self._probe_id}) accept: local={sockname} peer={peer}")
@@ -4385,7 +4413,6 @@ class WebSocketSession(ISession):
             )
             for wire in pending:
                 self._schedule_send(wire)
-                self._bump_tx(wire)
         except Exception as e:
             self._log.info(f"[WS/TX] ({self._probe_id}) flush error: {e!r}")
         finally:
@@ -4401,11 +4428,29 @@ class WebSocketSession(ISession):
         async def _tx_loop():
             try:
                 while True:
-                    wire = await self._tx_queue.get()
+                    wire, on_sent = await self._tx_queue.get()
                     try:
                         if not self._ws:
                             continue
-                        await self._ws.send(self._ws_payload_codec.encode(wire))
+                        send_coro = self._ws.send(self._ws_payload_codec.encode(wire))
+                        if self._ws_send_timeout_s > 0:
+                            await asyncio.wait_for(send_coro, timeout=self._ws_send_timeout_s)
+                        else:
+                            await send_coro
+                        self._bump_tx(wire)
+                        if callable(on_sent):
+                            try:
+                                on_sent()
+                            except Exception:
+                                pass
+                    except asyncio.TimeoutError:
+                        self._log.warning(
+                            f"[WS/TX] ({self._probe_id}) send timeout after {self._ws_send_timeout_s:.3f}s; forcing reconnect"
+                        )
+                        try:
+                            await asyncio.wait_for(self._ws.close(), timeout=1.0)
+                        except Exception:
+                            pass
                     except Exception as e:
                         self._log.info(f"[WS/TX] ({self._probe_id}) send error: {e!r}")
                     finally:
@@ -4415,11 +4460,56 @@ class WebSocketSession(ISession):
 
         self._tx_task = self._loop.create_task(_tx_loop())  # type: ignore
 
-    def _schedule_send(self, wire: bytes) -> None:
+    def _schedule_send(self, wire: bytes, on_sent: Optional[Callable[[], None]] = None) -> None:
         if not self._ws:
             return
         self._ensure_tx_task()
-        self._tx_queue.put_nowait(bytes(wire))
+        self._tx_queue.put_nowait((bytes(wire), on_sent))
+
+    def _configure_ws_socket(self, ws) -> None:
+        try:
+            transport = getattr(ws, "transport", None)
+            sock = transport.get_extra_info("socket") if transport else None
+            if not sock:
+                return
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            self._log.info(f"[WS-SESSION] ({self._probe_id}) SO_KEEPALIVE=1 set")
+            user_timeout = self._ws_tcp_user_timeout_ms
+            tcp_user_timeout = getattr(socket, "TCP_USER_TIMEOUT", None)
+            if user_timeout > 0 and tcp_user_timeout is not None:
+                sock.setsockopt(socket.IPPROTO_TCP, tcp_user_timeout, user_timeout)
+                self._log.info(
+                    f"[WS-SESSION] ({self._probe_id}) TCP_USER_TIMEOUT={user_timeout}ms set"
+                )
+        except Exception as e:
+            self._log.debug(f"[WS-SESSION] ({self._probe_id}) socket sockopt failed: {e!r}")
+
+
+    def _notify_peer_tx(self, nbytes: int) -> None:
+        if self._on_peer_tx:
+            try:
+                self._on_peer_tx(nbytes)
+            except Exception:
+                pass
+
+    def _schedule_overlay_disconnect(self) -> None:
+        if self._disconnect_task or not self._run_flag:
+            return
+        if self._ws_reconnect_grace_s <= 0:
+            self._set_overlay_connected(False)
+            return
+
+        async def _delayed_disconnect():
+            try:
+                await asyncio.sleep(self._ws_reconnect_grace_s)
+                if self._ws is None:
+                    self._set_overlay_connected(False)
+            except asyncio.CancelledError:
+                return
+            finally:
+                self._disconnect_task = None
+
+        self._disconnect_task = self._loop.create_task(_delayed_disconnect())  # type: ignore
 
     def _decode_ws_message(self, msg) -> Optional[bytes]:
         if isinstance(msg, str):
@@ -4562,14 +4652,8 @@ class WebSocketSession(ISession):
         except Exception:
             pass
 
-        self._schedule_send(body)
-        self._bump_tx(body)
-        if self._on_peer_tx:
-            try:
-                self._on_peer_tx(len(body))
-            except Exception:
-                pass
-        self._log.debug(f"[WS/TX] ({self._probe_id}) PING")
+        self._schedule_send(body, on_sent=lambda: self._notify_peer_tx(len(body)))
+        self._log.debug(f"[WS/TX] ({self._probe_id}) PING queued")
             
     def _send_pong_frame(self, echo_tx_ns: int) -> None:
         if not self._ws:
@@ -4580,14 +4664,8 @@ class WebSocketSession(ISession):
         # Guard log
         self._log.debug(f"[WS/GUARD] ({self._probe_id}) PONG tx: echo_tx_ns={echo_tx_ns}")
 
-        self._schedule_send(body)
-        self._bump_tx(body)
-        if self._on_peer_tx:
-            try:
-                self._on_peer_tx(len(body))
-            except Exception:
-                pass
-        self._log.debug(f"[WS/TX] ({self._probe_id}) PONG")
+        self._schedule_send(body, on_sent=lambda: self._notify_peer_tx(len(body)))
+        self._log.debug(f"[WS/TX] ({self._probe_id}) PONG queued")
 
     # --- RX pump ---------------------------------------------------------------
     async def _rx_pump(self) -> None:
@@ -4668,7 +4746,7 @@ class WebSocketSession(ISession):
             except Exception:
                 pass
             self._ws = None
-            self._set_overlay_connected(False)
+            self._schedule_overlay_disconnect()
             if self._peer_tuple:
                 self._start_reconnect_loop()
             self._log.debug(f"[WS/RX] ({self._probe_id}) pump stop")


### PR DESCRIPTION
### Motivation
- Prevent stalled/broken WebSocket sends from hanging the session by enforcing a configurable send timeout. 
- Configure socket keepalive and `TCP_USER_TIMEOUT` to make stalled TCP connections more detectable. 
- Ensure transmit accounting (`_tx_bytes` / peer TX callback) only occurs after a successful send and avoid double-counting when flushing early buffers. 
- Avoid immediately reporting overlay disconnect on WS close by adding a short reconnect grace window to tolerate quick reconnects.

### Description
- Added CLI arguments `--ws-send-timeout`, `--ws-tcp-user-timeout-ms`, and `--ws-reconnect-grace` and stored them as `_ws_send_timeout_s`, `_ws_tcp_user_timeout_ms`, and `_ws_reconnect_grace_s` on `WebSocketSession`.
- Changed the transmit queue to store `(wire, on_sent)` tuples and added an `on_sent` callback path so accounting is done after a successful `await ws.send(...)` inside the `_tx_loop`.
- Enforced send timeout with `asyncio.wait_for(send_coro, timeout=self._ws_send_timeout_s)` and force-closed the websocket on timeout to trigger reconnect behavior.
- Added `_configure_ws_socket` to set `SO_KEEPALIVE` and `TCP_USER_TIMEOUT` (when available) on the websocket transport socket, with safe error handling.
- Implemented `_schedule_overlay_disconnect` to delay overlay `DISCONNECTED` state by `_ws_reconnect_grace_s` seconds and cancel the pending disconnect when a new connection is accepted; ensured cancel/cleanup in `stop` and `_on_accept`.
- Updated `send_app`, `_send_ping_frame`, `_send_pong_frame`, and `_flush_early` to enqueue sends using the new `on_sent` semantics and removed immediate accounting from the enqueue path.
- Added helper `_notify_peer_tx` to centralize peer TX callback invocation and added tests and small test helpers (`_FakeWs`, `_HangingWs`, `_FakeSocket`, `_FakeTransport`, `_SockoptWs`).
- Expanded `test_ws_payload_mode.py` with async tests for TX accounting, send timeout behavior, socket option configuration, and reconnect grace behavior, plus adjusted test harness defaults.

### Testing
- Ran the unit tests in `test_ws_payload_mode.py`, including `WebSocketTxLoopTests.*`, `WebSocketSocketConfigTests.*`, `WebSocketReconnectGraceTests.*`, and the existing payload codec tests, and they all succeeded. 
- Verified new async behaviors under `IsolatedAsyncioTestCase` for successful send accounting, timeout-triggered close, socket option setting, and reconnect-grace timed disconnect behavior, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd52dbe5e483229ebb00525ee085d4)