### PR TITLE
Disable websockets open_timeout and increase write_limit for HTTP asset transfers; update tests

### DIFF
--- a/test_ws_payload_mode.py
+++ b/test_ws_payload_mode.py
@@ -312,6 +312,8 @@ class WebSocketCompressionConfigTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIs(session._server, fake_server)
         self.assertEqual(serve.await_args.kwargs["compression"], None)
+        self.assertIsNone(serve.await_args.kwargs["open_timeout"])
+        self.assertEqual(serve.await_args.kwargs["write_limit"], 131072)
 
     async def test_connect_disables_websocket_compression(self):
         args = _args("binary")

--- a/udp_bidirectional_main.py
+++ b/udp_bidirectional_main.py
@@ -4222,8 +4222,10 @@ class WebSocketSession(ISession):
             subprotocols=subprotocols,
             max_size=self._ws_max_size,
             compression=self._ws_compression,
+            open_timeout=None,  # static HTTP requests may stay non-WS during asset transfer
             ping_interval=None,  # we run our own RTT ping
             ping_timeout=None,
+            write_limit=max(131072, self._ws_max_size or 0),  # allow larger HTTP responses to flush before close
             process_request=_process_request,  # <-- key: serve static before WS
         )
 


### PR DESCRIPTION
### Motivation

- Static HTTP asset requests served alongside WebSocket connections can remain non-WS for an extended time, so the server `open_timeout` needs to be disabled to avoid premature connection close.
- Larger HTTP responses may exceed the default transport buffer, so `write_limit` is increased to allow a full response to flush before the server closes the connection, and tests updated to reflect these options.

### Description

- Set `open_timeout=None` on the `websockets.serve` call to allow long-running non-WebSocket HTTP requests to complete without being closed by the handshake timeout. 
- Set `write_limit=max(131072, self._ws_max_size or 0)` on `websockets.serve` to permit larger HTTP responses to be written before the transport backpressure triggers closure. 
- Updated `test_ws_payload_mode.py` to assert the new `open_timeout` and `write_limit` kwargs on the mocked `serve` call.

### Testing

- Ran the updated unit tests in `test_ws_payload_mode.py` covering `WebSocketCompressionConfigTests`, and the new assertions for `open_timeout` and `write_limit` passed.
- Existing tests that verify compression and preflight behavior (`test_start_server_disables_websocket_compression` and `test_connect_disables_websocket_compression`) were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be8023c2ec8322a4822894a0be90a5)