### PR TITLE
Add websocket static HTTP transfer probes and decision logs

### DIFF
--- a/test_ws_payload_mode.py
+++ b/test_ws_payload_mode.py
@@ -3,6 +3,7 @@ import argparse
 import asyncio
 import socket
 import sys
+import tempfile
 import types
 import unittest
 from unittest import mock
@@ -113,6 +114,46 @@ class _SockoptWs(_FakeWs):
     def __init__(self, sock):
         super().__init__()
         self.transport = _FakeTransport(sock)
+
+
+class _ProbeTransport:
+    def __init__(self):
+        self._sockname = ("127.0.0.1", 8080)
+        self._peername = ("127.0.0.1", 40000)
+
+    def get_write_buffer_size(self):
+        return 0
+
+    def is_closing(self):
+        return False
+
+    def get_extra_info(self, name):
+        if name == "sockname":
+            return self._sockname
+        if name == "peername":
+            return self._peername
+        return None
+
+
+class _ProbeConnection:
+    def __init__(self):
+        self.transport = _ProbeTransport()
+
+
+class _FakeLoop:
+    def __init__(self):
+        self.calls = []
+
+    def call_soon(self, cb, *args):
+        self.calls.append(("soon", 0.0, cb, args))
+
+    def call_later(self, delay, cb, *args):
+        self.calls.append(("later", delay, cb, args))
+
+
+class _FakeResponse:
+    def __init__(self, *args):
+        self.args = args
 
 class WebSocketPayloadModeTests(unittest.TestCase):
     def test_binary_mode_keeps_bytes_on_send(self):
@@ -341,6 +382,59 @@ class WebSocketCompressionConfigTests(unittest.IsolatedAsyncioTestCase):
         preflight.assert_awaited_once()
         on_accept.assert_awaited_once_with(fake_ws)
         self.assertEqual(connect.await_args.kwargs["compression"], None)
+
+
+class WebSocketStaticHttpDebugTests(unittest.IsolatedAsyncioTestCase):
+    async def test_start_server_schedules_static_http_probes_for_modern_requests(self):
+        args = _args("binary")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            icon_path = f"{tmpdir}/icon.png"
+            with open(icon_path, "wb") as fh:
+                fh.write(b"\x89PNG" + b"x" * 32)
+
+            args.ws_static_dir = tmpdir
+            session = WebSocketSession(args)
+            session._loop = _FakeLoop()
+            session._run_flag = True
+            session._log = mock.Mock()
+
+            fake_server = types.SimpleNamespace(
+                sockets=[types.SimpleNamespace(getsockname=lambda: ("127.0.0.1", 54321))]
+            )
+            serve = mock.AsyncMock(return_value=fake_server)
+            fake_websockets = types.SimpleNamespace(serve=serve)
+            fake_http11 = types.SimpleNamespace(Response=_FakeResponse)
+            fake_ds = types.SimpleNamespace(Headers=lambda items: items)
+
+            with mock.patch.dict(
+                sys.modules,
+                {
+                    "websockets": fake_websockets,
+                    "websockets.http11": fake_http11,
+                    "websockets.datastructures": fake_ds,
+                },
+            ):
+                await session._start_server()
+
+            process_request = serve.await_args.kwargs["process_request"]
+            request = types.SimpleNamespace(method="GET", path="/icon.png", headers={})
+            response = process_request(_ProbeConnection(), request)
+
+            self.assertIsInstance(response, _FakeResponse)
+            self.assertEqual(
+                [kind for kind, *_ in session._loop.calls],
+                ["soon", "later", "later", "later"],
+            )
+            self.assertEqual(
+                [delay for _, delay, _, _ in session._loop.calls],
+                [0.0, 0.05, 0.25, 1.0],
+            )
+            debug_messages = [
+                call.args[0]
+                for call in session._log.debug.call_args_list
+                if call.args
+            ]
+            self.assertTrue(any("[WS/HTTP]" in msg and "static-hit" in msg for msg in debug_messages))
 
 
 if __name__ == "__main__":

--- a/udp_bidirectional_main.py
+++ b/udp_bidirectional_main.py
@@ -3888,6 +3888,7 @@ class WebSocketSession(ISession):
 
         # Static HTTP root
         self._ws_static_dir: Optional[str] = getattr(self._args, "ws_static_dir", "./web") or None
+        self._static_http_probe_delays_s: tuple[float, ...] = (0.0, 0.05, 0.25, 1.0)
 
     # ---- ISession wiring ------------------------------------------------------
     def set_on_app_payload(self, cb): self._on_app = cb
@@ -3993,6 +3994,94 @@ class WebSocketSession(ISession):
         return len(payload)
 
     # ---- Internals ------------------------------------------------------------
+
+    def _describe_transport_state(self, connection) -> str:
+        transport = getattr(connection, "transport", None)
+        if transport is None:
+            return "transport=missing"
+
+        parts: list[str] = []
+        try:
+            parts.append(f"wbuf={transport.get_write_buffer_size()}")
+        except Exception as e:
+            parts.append(f"wbuf=?({e!r})")
+        try:
+            parts.append(f"closing={bool(transport.is_closing())}")
+        except Exception as e:
+            parts.append(f"closing=?({e!r})")
+
+        try:
+            sockname = transport.get_extra_info("sockname")
+            if sockname is not None:
+                parts.append(f"sockname={sockname}")
+        except Exception:
+            pass
+        try:
+            peername = transport.get_extra_info("peername")
+            if peername is not None:
+                parts.append(f"peer={peername}")
+        except Exception:
+            pass
+        return " ".join(parts)
+
+    def _log_static_http_decision(
+        self,
+        *,
+        method: str,
+        req_path: str,
+        status: int,
+        target,
+        ctype: str,
+        content_length: int,
+        body_length: int,
+        note: str = "",
+    ) -> None:
+        target_txt = "-" if target is None else str(target)
+        suffix = f" note={note}" if note else ""
+        self._log.debug(
+            f"[WS/HTTP] ({self._probe_id}) method={method} path={req_path} status={status} "
+            f"target={target_txt} ctype={ctype} content_length={content_length} body_length={body_length}{suffix}"
+        )
+
+    def _schedule_static_http_debug_probes(
+        self,
+        connection,
+        *,
+        method: str,
+        req_path: str,
+        status: int,
+        target,
+        body_length: int,
+    ) -> None:
+        loop = self._loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                return
+        if loop is None:
+            return
+
+        target_txt = "-" if target is None else str(target)
+
+        def _emit_probe(delay_s: float) -> None:
+            self._log.debug(
+                f"[WS/HTTP] ({self._probe_id}) probe dt={delay_s:.3f}s method={method} "
+                f"path={req_path} status={status} body_length={body_length} target={target_txt} "
+                f"{self._describe_transport_state(connection)}"
+            )
+
+        for delay_s in self._static_http_probe_delays_s:
+            try:
+                if delay_s <= 0:
+                    loop.call_soon(_emit_probe, delay_s)
+                else:
+                    loop.call_later(delay_s, _emit_probe, delay_s)
+            except Exception as e:
+                self._log.debug(
+                    f"[WS/HTTP] ({self._probe_id}) failed to schedule probe delay={delay_s:.3f}s "
+                    f"path={req_path}: {e!r}"
+                )
 
     async def _start_server(self) -> None:
         """
@@ -4114,25 +4203,65 @@ class WebSocketSession(ISession):
                 pass
 
             method = getattr(request, "method", "GET") or "GET"
+            req_path = getattr(request, "path", "/") or "/"
             if method not in ("GET", "HEAD"):
                 body = b"Method Not Allowed\n"
+                self._log_static_http_decision(
+                    method=method,
+                    req_path=req_path,
+                    status=405,
+                    target=None,
+                    ctype="text/plain",
+                    content_length=len(body),
+                    body_length=len(body),
+                    note="method-not-allowed",
+                )
                 return _mk_response(405, [("Allow", "GET, HEAD")] + _http_headers(405, len(body), "text/plain"), body)
 
-            req_path = getattr(request, "path", "/") or "/"
             target = _safe_join(static_root, req_path)
             if target is None:
                 body = b"Forbidden\n"
+                self._log_static_http_decision(
+                    method=method,
+                    req_path=req_path,
+                    status=403,
+                    target=None,
+                    ctype="text/plain",
+                    content_length=len(body),
+                    body_length=len(body),
+                    note="safe-join-rejected",
+                )
                 return _mk_response(403, _http_headers(403, len(body), "text/plain"), body)
 
             if target.is_dir():
                 index = target / "index.html"
                 if not (index.exists() and index.is_file()):
                     body = b"Not Found\n"
+                    self._log_static_http_decision(
+                        method=method,
+                        req_path=req_path,
+                        status=404,
+                        target=target,
+                        ctype="text/plain",
+                        content_length=len(body),
+                        body_length=len(body),
+                        note="directory-without-index",
+                    )
                     return _mk_response(404, _http_headers(404, len(body), "text/plain"), body)
                 target = index
 
             if not target.exists() or not target.is_file():
                 body = b"Not Found\n"
+                self._log_static_http_decision(
+                    method=method,
+                    req_path=req_path,
+                    status=404,
+                    target=target,
+                    ctype="text/plain",
+                    content_length=len(body),
+                    body_length=len(body),
+                    note="missing-file",
+                )
                 return _mk_response(404, _http_headers(404, len(body), "text/plain"), body)
 
             ctype = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
@@ -4141,10 +4270,56 @@ class WebSocketSession(ISession):
             except Exception as e:
                 self._log.debug(f"[WS-SESSION] ({self._probe_id}) static read error: {e!r}")
                 body = b"Internal Server Error\n"
+                self._log_static_http_decision(
+                    method=method,
+                    req_path=req_path,
+                    status=500,
+                    target=target,
+                    ctype="text/plain",
+                    content_length=len(body),
+                    body_length=len(body),
+                    note=f"read-error={e!r}",
+                )
                 return _mk_response(500, _http_headers(500, len(body), "text/plain"), body)
 
             if method == "HEAD":
+                self._log_static_http_decision(
+                    method=method,
+                    req_path=req_path,
+                    status=200,
+                    target=target,
+                    ctype=ctype,
+                    content_length=len(data),
+                    body_length=0,
+                    note="head-response",
+                )
+                self._schedule_static_http_debug_probes(
+                    connection,
+                    method=method,
+                    req_path=req_path,
+                    status=200,
+                    target=target,
+                    body_length=0,
+                )
                 return _mk_response(200, _http_headers(200, len(data), ctype), b"")
+            self._log_static_http_decision(
+                method=method,
+                req_path=req_path,
+                status=200,
+                target=target,
+                ctype=ctype,
+                content_length=len(data),
+                body_length=len(data),
+                note="static-hit",
+            )
+            self._schedule_static_http_debug_probes(
+                connection,
+                method=method,
+                req_path=req_path,
+                status=200,
+                target=target,
+                body_length=len(data),
+            )
             return _mk_response(200, _http_headers(200, len(data), ctype), data)
 
         # --- Legacy handler: (path, request_headers) -> (status, headers, body)|None ---
@@ -4165,17 +4340,47 @@ class WebSocketSession(ISession):
             target = _safe_join(static_root, path or "/")
             if target is None:
                 body = b"Forbidden\n"
+                self._log_static_http_decision(
+                    method=method,
+                    req_path=path or "/",
+                    status=403,
+                    target=None,
+                    ctype="text/plain",
+                    content_length=len(body),
+                    body_length=len(body),
+                    note="safe-join-rejected",
+                )
                 return 403, _http_headers(403, len(body), "text/plain"), body
 
             if target.is_dir():
                 index = target / "index.html"
                 if not (index.exists() and index.is_file()):
                     body = b"Not Found\n"
+                    self._log_static_http_decision(
+                        method=method,
+                        req_path=path or "/",
+                        status=404,
+                        target=target,
+                        ctype="text/plain",
+                        content_length=len(body),
+                        body_length=len(body),
+                        note="directory-without-index",
+                    )
                     return 404, _http_headers(404, len(body), "text/plain"), body
                 target = index
 
             if not target.exists() or not target.is_file():
                 body = b"Not Found\n"
+                self._log_static_http_decision(
+                    method=method,
+                    req_path=path or "/",
+                    status=404,
+                    target=target,
+                    ctype="text/plain",
+                    content_length=len(body),
+                    body_length=len(body),
+                    note="missing-file",
+                )
                 return 404, _http_headers(404, len(body), "text/plain"), body
 
             ctype = mimetypes.guess_type(str(target))[0] or "application/octet-stream"
@@ -4184,8 +4389,28 @@ class WebSocketSession(ISession):
             except Exception as e:
                 self._log.debug(f"[WS-SESSION] ({self._probe_id}) static read error: {e!r}")
                 body = b"Internal Server Error\n"
+                self._log_static_http_decision(
+                    method=method,
+                    req_path=path or "/",
+                    status=500,
+                    target=target,
+                    ctype="text/plain",
+                    content_length=len(body),
+                    body_length=len(body),
+                    note=f"read-error={e!r}",
+                )
                 return 500, _http_headers(500, len(body), "text/plain"), body
 
+            self._log_static_http_decision(
+                method=method,
+                req_path=path or "/",
+                status=200,
+                target=target,
+                ctype=ctype,
+                content_length=len(data),
+                body_length=len(data),
+                note="static-hit",
+            )
             return 200, _http_headers(200, len(data), ctype), data
 
         # --- One wrapper that adapts to either signature ---


### PR DESCRIPTION
### Motivation
- Static file transfers served via the WebSocket server can stall or be interrupted (e.g. `icon.png` not fully transferred), and the existing logs did not provide enough transport state to diagnose where the send/close path was failing.
- Short follow-up probes of the underlying transport after queuing an HTTP response should reveal whether the stall happens inside the socket write buffer, during close, or elsewhere.

### Description
- Add `_static_http_probe_delays_s` and three helper methods: `_describe_transport_state`, `_log_static_http_decision`, and `_schedule_static_http_debug_probes` to `udp_bidirectional_main.py` to emit structured decision logs and timed transport probes for static HTTP responses.
- Instrument the process_request handlers (`_process_request_modern` and `_process_request_legacy`) to log each static-file decision (method, path, resolved target, MIME type, declared content length, actual body length, and a `note`) and to schedule transport probes on successful 200 responses and on HEAD responses.
- The probe messages include `wbuf=<bytes>`, `closing=<bool>`, and socket `sockname`/`peer` when available to help correlate stalled transfers with socket state.
- Add unit test `WebSocketStaticHttpDebugTests:test_start_server_schedules_static_http_probes_for_modern_requests` to `test_ws_payload_mode.py` that exercises the modern `process_request` flow, verifies a `Response` is returned, checks the scheduled probe timings, and asserts that a `static-hit` debug message was produced.

### Testing
- Ran the test suite with `python -m unittest test_ws_payload_mode.py` and all tests passed (17 tests, `OK`).
- Verified syntax/compilation with `python -m py_compile udp_bidirectional_main.py test_ws_payload_mode.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be86b0a14083228319f3f2c72e5f9f)