### PR TITLE
Add multi-transport runner and multi-peer WebSocket server, docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,162 @@
 # ObstacleBridge
-
-This repository now uses a package-oriented Python layout for the ObstacleBridge project.
-
-## Project layout
-
-- `src/obstacle_bridge/` – application modules.
-- `tests/unit/` – focused unit tests.
-- `tests/integration/` – subprocess and end-to-end scenarios.
-- `scripts/` – standalone development/test harness scripts.
-- `docs/` – historical notes and testing documentation.
-
+ObstacleBridge is a Python-based overlay and channel-multiplexing toolkit for barrier-resilient networking. It can run over multiple overlay transports (`myudp`, `tcp`, `quic`, `ws`), expose local TCP/UDP listener services through a reliable overlay, and host an admin UI for monitoring active channels.
+## Repository layout
+- `src/obstacle_bridge/` — main implementation.
+- `tests/unit/` — targeted unit tests.
+- `tests/integration/` — end-to-end and subprocess tests.
+- `scripts/` — development helpers.
+- `docs/WHITEPAPER.html` — full whitepaper requested for this repository update.
 ## Entry points
-
-The renamed primary root-level entry point is:
-
+- `python -m obstacle_bridge --help`
 - `ObstacleBridge.py`
-
-Legacy wrappers are still available for compatibility:
-
-- `udp_bidirectional_main.py`
-- `udp_bidirectional_transfer.py`
-- `overlay_tty.py`
-- `extract_udp_debug.py`
-- `run_udp_bidir_tests.py`
-
-You can also invoke the packaged module with:
-
+- Compatibility wrappers: `udp_bidirectional_main.py`, `udp_bidirectional_transfer.py`, `overlay_tty.py`, `extract_udp_debug.py`, `run_udp_bidir_tests.py`.
+## Quick-start examples
+### 1) Single overlay transport listener
 ```bash
-python -m obstacle_bridge --help
+python -m obstacle_bridge --overlay-transport ws --bind443 0.0.0.0 --port443 54321
 ```
+### 2) Multi-transport listening instance
+```bash
+python -m obstacle_bridge \
+  --overlay-transport "myudp,tcp,quic,ws" \
+  --port443 443 \
+  --overlay-port-tcp 444 \
+  --overlay-port-quic 445 \
+  --overlay-port-ws 446 \
+  --quic-cert cert.pem \
+  --quic-key key.pem
+```
+If explicit per-transport ports are omitted in multi-transport listener mode, ObstacleBridge derives deterministic offsets from `--port443`: `myudp:+0`, `tcp:+1`, `quic:+2`, `ws:+3`.
+### 3) Peer client exposing local services
+```bash
+python -m obstacle_bridge \
+  --overlay-transport ws \
+  --peer 203.0.113.10 --peer-port 446 \
+  --own-servers "udp,16667,0.0.0.0,udp,127.0.0.1,16666 tcp,3129,0.0.0.0,tcp,127.0.0.1,3128"
+```
+## CLI parameter reference
+The tables below are generated from the current parser registrations in `bridge.py`, so the defaults and descriptions match the live code.
+### General / status
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--status` | `True` | enable periodic status (default: on) |
+| `--no-dashboard` | `False` | disable non-scrolling dashboard (print multiline blocks instead) |
+
+### UDP overlay
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--bind443` | `::` | overlay bind address (IPv4 '0.0.0.0' or IPv6 '::') |
+| `--port443` | `443` | overlay listen port |
+| `--peer` | `None` | peer IP/FQDN (IPv4 or IPv6 literal; IPv6 may be in [brackets]) |
+| `--peer-port` | `443` | peer overlay port |
+| `--peer-resolve-family` | `prefer-ipv6` | Peer name resolution policy: prefer IPv6 then IPv4, IPv4 only, or IPv6 only. |
+| `--max-inflight` | `32767` | max DATA frames allowed in flight (1..32767). Excess frames are queued. |
+
+### WebSocket overlay
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--ws-path` | `/` | WebSocket HTTP path (default /) |
+| `--ws-subprotocol` | `None` | Optional WebSocket subprotocol (e.g. mux2) |
+| `--ws-tls` | `False` | Use TLS (wss://). Provide cert/key via your deployment. |
+| `--ws-max-size` | `65535` | Maximum binary message size to accept/send (default 65535). |
+| `--ws-payload-mode` | `binary` | WebSocket payload transfer mode: raw binary frames (default), base64 text frames, or JSON text frames with the base64 payload in the data field. |
+| `--ws-static-dir` | `./web` | Directory to serve as a static web root on the WS port (default ./web). Set to '' to disable. |
+| `--ws-send-timeout` | `3.0` | Seconds to wait for a WebSocket frame send before forcing reconnect (default 3.0). |
+| `--ws-tcp-user-timeout-ms` | `10000` | TCP_USER_TIMEOUT in milliseconds for WebSocket sockets (default 10000, 0 disables). |
+| `--ws-reconnect-grace` | `3.0` | Seconds to wait before reporting DISCONNECTED after WS transport loss (default 3.0). |
+
+### TCP overlay
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--tcp-bp-wbuf-threshold` | `131072` | TCP overlay: write() buffer size threshold in bytes to signal drain (default 131072). |
+| `--tcp-bp-latency-ms` | `300` | TCP overlay: if > 0, trigger drain after this latency (ms) whenever pending bytes exist. |
+| `--tcp-bp-poll-interval-ms` | `50` | TCP overlay: polling interval for time-based backpressure checks (ms; default 50). |
+
+### QUIC overlay
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--quic-alpn` | `hq-29` | ALPN protocol ID (default hq-29) |
+| `--quic-cert` | `None` | Server certificate file (PEM) |
+| `--quic-key` | `None` | Server private key file (PEM) |
+| `--quic-insecure` | `False` | Client: disable certificate verification (TEST ONLY) |
+| `--quic-max-size` | `65535` | Maximum app message size accepted/sent (default 65535). |
+
+### Channel mux
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--own-servers` | `None` | Space-separated service specs (client mode only): 'proto,listen_port,listen_bind,proto,host,port' (quoted). Listener instances ignore --own-servers because multiple overlay peers make the target ambiguous. Example: "tcp,80,0.0.0.0,tcp,127.0.0.1,88 udp,16666,::,udp,127.0.0.1,16666" |
+| `--mux-tcp-bp-threshold` | `1` | Mux TCP: size threshold (bytes) to trigger drain() (default 1). |
+| `--mux-tcp-bp-latency-ms` | `300` | Mux TCP: if > 0, drain writers after this ms when bytes pending. |
+| `--mux-tcp-bp-poll-interval-ms` | `50` | Mux TCP: polling interval for time-based backpressure (ms). |
+
+### Admin web
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--admin-web` | `False` | Enable admin web interface |
+| `--admin-web-bind` | `127.0.0.1` | Bind address for admin web interface |
+| `--admin-web-port` | `18080` | Port for admin web interface |
+| `--admin-web-path` | `/` | Base path for admin web interface |
+| `--admin-web-dir` | `./admin_web` | Directory containing admin web files |
+| `--admin-web-token` | `` | Optional bearer token for admin restart endpoint |
+
+### Logging
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--log` | `WARNING` | logging level (default WARNING; try INFO or DEBUG) be aware of --console-level and --file-level |
+| `--log-file` | `None` | file path to also write logs enabled by --log |
+| `--console-level` | `INFO` | console (stdout) logging level (default INFO) |
+| `--file-level` | `DEBUG` | file logging level (default: same as --log) |
+| `--debug-stderr` | `False` | mirror DEBUG lines to stderr (default: off) |
+
+### Runner
+| Option(s) | Default | Description |
+|---|---:|---|
+| `--overlay-transport` | `myudp` | Overlay transport between peers: comma-separated list from myudp,tcp,quic,ws. Multiple transports are supported simultaneously for listening instances. |
+| `--overlay-port-myudp` | `None` | Optional listen port override for overlay transport myudp. Defaults to --port443 or a deterministic offset when multiple transports are active. |
+| `--overlay-port-tcp` | `None` | Optional listen port override for overlay transport tcp. Defaults to --port443 or a deterministic offset when multiple transports are active. |
+| `--overlay-port-quic` | `None` | Optional listen port override for overlay transport quic. Defaults to --port443 or a deterministic offset when multiple transports are active. |
+| `--overlay-port-ws` | `None` | Optional listen port override for overlay transport ws. Defaults to --port443 or a deterministic offset when multiple transports are active. |
+| `--client-restart-if-disconnected` | `0.0` | If configured as a peer client (--peer set) and overlay stays disconnected for this many seconds, request process restart. 0 disables. |
+
+## Whitepaper
+The complete whitepaper requested for this project update is included verbatim in [`docs/WHITEPAPER.html`](docs/WHITEPAPER.html). It covers:
+- Internet barriers such as NAT, DPI, protocol blocking, traffic shaping, and TLS interception.
+- Transport-level behavior for IP, ICMP, UDP, TCP, QUIC, DNS, HTTP/HTTPS, and WebSockets.
+- The layered overlay architecture used here: RTT/liveness, reliable DATA/CONTROL framing, and ChannelMux OPEN/DATA/CLOSE multiplexing.
+- Why UDP overlays can outperform TCP-over-TCP tunnels on hostile paths.
+- Development-process lessons from AI-supported programming.
+### Whitepaper abstract
+> This whitepaper presents a detailed technical explanation of Internet communication mechanisms and a Python-based UDP overlay protocol designed to work across restrictive network environments. The report explains how modern Internet barriers such as NAT, IPv4/IPv6 asymmetry, deep packet inspection, protocol blocking, traffic shaping, and throttling affect connectivity, and how a layered UDP overlay can reconstruct connection detection, round-trip-time measurement, loss recovery, retransmission, and multi-channel multiplexing in user space.
+### Whitepaper table of contents
+1. Introduction  
+2. Internet Services and Their Performance Requirements  
+3. Routing Fundamentals: Hubs, Switches, Routers, VPN Paths, and the Layer Model  
+4. Modern Internet Barriers  
+5. Internet Protocol (IP)  
+6. ICMP Protocol  
+7. UDP Protocol  
+8. TCP Protocol  
+9. TCP Congestion Control  
+10. TCP Backpressure and Flow Control  
+11. QUIC Protocol  
+12. DNS Protocol  
+13. HTTP, HTTPS, and WebSockets  
+14. Deep Packet Inspection and TLS Interception  
+15. VPNs, HTTP Proxies, and Tunneling  
+16. Why a UDP Overlay Helps  
+17. Overlay Architecture Overview  
+18. Overlay Architecture Overview  
+19. Layer 1: Connection Detection and RTT Measurement  
+20. Layer 2: Reliable DATA / CONTROL Protocol  
+21. Layer 3: ChannelMux OPEN / DATA / CLOSE Protocol  
+22. End-to-End Example: Browser via HTTP Proxy over Overlay  
+23. Why This Can Improve Performance  
+24. Detailed TCP-over-TCP Problem Example  
+25. Limitations and Engineering Considerations  
+26. Development Procedure and Experience with AI-Supported Programming  
+27. Conclusion  
+References
+## Notes
+- Listener mode intentionally ignores `--own-servers`, because a multi-peer listener cannot unambiguously bind one local listener to one remote peer.
+- Multi-transport mode is currently intended for listening instances without `--peer`.
+- WebSocket listener mode supports multiple simultaneous peers with per-peer mux-channel rewriting so that peer-local channel IDs do not collide inside the shared mux logic.

--- a/docs/WHITEPAPER.html
+++ b/docs/WHITEPAPER.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1" name="viewport"/>
+<title>UDP Overlay Networking Whitepaper - merged baseline</title>
+<style>
+body { font-family: Georgia, "Times New Roman", serif; margin: 0; background: #f7f7f7; color: #111; }
+.container { max-width: 980px; margin: 0 auto; background: white; padding: 48px 56px; box-shadow: 0 1px 8px rgba(0,0,0,.08); }
+h1 { font-size: 2.2rem; margin-bottom: .2rem; }
+h2 { margin-top: 2.2rem; border-bottom: 1px solid #ccc; padding-bottom: .3rem; }
+h3 { margin-top: 1.2rem; }
+p, li, td, th { font-size: 1rem; line-height: 1.6; }
+table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+th, td { border: 1px solid #bbb; padding: 8px 10px; vertical-align: top; }
+th { background: #efefef; text-align: left; }
+pre { background: #f4f6f8; border: 1px solid #d9e0e6; padding: 14px; overflow-x: auto; white-space: pre-wrap; }
+.diagram { background: #f9fbff; }
+.subtitle { color: #444; margin-bottom: 2rem; }
+</style>
+</head>
+<body>
+<div class="container">
+<h1>UDP Overlay Networking for Barrier-Resilient Internet Communication</h1>
+<div class="subtitle">Merged Technical Whitepaper (rich baseline + approved additions)</div>
+<h2>Table of Contents</h2>
+<p>This table of contents is intended for easier manual navigation inside the HTML document.</p>
+<ol>
+<li>1. Introduction</li>
+<li>2. Internet Services and Their Performance Requirements</li>
+<li>3. Routing Fundamentals: Hubs, Switches, Routers, VPN Paths, and the Layer Model</li>
+<li>4. Modern Internet Barriers</li>
+<li>5. Internet Protocol (IP)</li>
+<li>6. ICMP Protocol</li>
+<li>7. UDP Protocol</li>
+<li>8. TCP Protocol</li>
+<li>9. TCP Congestion Control</li>
+<li>10. TCP Backpressure and Flow Control</li>
+<li>11. QUIC Protocol</li>
+<li>12. DNS Protocol</li>
+<li>13. HTTP, HTTPS, and WebSockets</li>
+<li>14. Deep Packet Inspection and TLS Interception</li>
+<li>15. VPNs, HTTP Proxies, and Tunneling</li>
+<li>16. Why a UDP Overlay Helps</li>
+<li>17. Overlay Architecture Overview</li>
+<li>18. Overlay Architecture Overview</li>
+<li>19. Layer 1: Connection Detection and RTT Measurement</li>
+<li>20. Layer 2: Reliable DATA / CONTROL Protocol</li>
+<li>21. Layer 3: ChannelMux OPEN / DATA / CLOSE Protocol</li>
+<li>22. End-to-End Example: Browser via HTTP Proxy over Overlay</li>
+<li>23. Why This Can Improve Performance</li>
+<li>24. Detailed TCP-over-TCP Problem Example</li>
+<li>25. Limitations and Engineering Considerations</li>
+<li>26. Development Procedure and Experience with AI-Supported Programming</li>
+<li>27. Conclusion</li>
+<li>References</li>
+</ol>
+<h2>Abstract</h2>
+<p>This whitepaper presents a detailed technical explanation of Internet communication mechanisms and a Python-based UDP overlay protocol designed to work across restrictive network environments. The document targets readers who use web browsers and Internet services every day but are not deeply familiar with HTTP, HTTPS, DNS, TCP, QUIC, IP, routing, and tunneling internals.</p>
+<p>The report explains how modern Internet barriers such as NAT, IPv4/IPv6 asymmetry, deep packet inspection, protocol blocking, traffic shaping, and throttling affect connectivity. It then explains how a layered UDP overlay can reconstruct connection detection, round-trip-time measurement, loss recovery, retransmission, and multi-channel multiplexing in user space.</p>
+<p>Special attention is given to the actual protocol structure reflected in the Python implementation: BaseFrameV2 without a MAGIC field, a lowest layer for liveness and RTT estimation, a reliability layer using DATA and CONTROL frames, and a ChannelMux layer using OPEN, DATA, and CLOSE frames over already-reliable transport.</p>
+<h2>1. Introduction</h2>
+<p>The original vision of the Internet assumed end-to-end reachability. A host connected to the network should, in principle, be able to communicate with any other host. In practice, the modern Internet has evolved far away from that model. Address scarcity led to large-scale use of Network Address Translation. Security concerns led to firewalls, incoming connection filtering, TLS interception appliances, and application-aware policy enforcement. Commercial interests led to traffic shaping, protocol discrimination, and geographic blocking.</p>
+<p>As a result, the path between machine A and machine B is often no longer a neutral packet-forwarding medium. It is a managed and filtered environment that can systematically disadvantage certain kinds of traffic. UDP overlay protocols are attractive in this setting because they allow the application designer to rebuild the transport behavior that is actually needed, instead of accepting the exact semantics and limitations of TCP as imposed by the network path.</p>
+<h2>2. Internet Services and Their Performance Requirements</h2>
+<p>Different Internet applications stress the network in different ways. Web browsing generally tolerates moderate latency but benefits from reliable transfer and low startup delay. Large downloads mainly demand throughput and stability. Audio calls demand low one-way delay and low jitter. Video calls demand low latency, continuity, and moderate-to-high bandwidth. Text messaging requires little bandwidth but benefits from fast delivery. Streaming video can tolerate some packet loss through buffering, but sustained loss and jitter degrade quality.</p>
+<table>
+<tr><th>Service</th><th>Latency Sensitivity</th><th>Bandwidth Need</th><th>Loss Sensitivity</th><th>Steadiness / Jitter Sensitivity</th></tr>
+<tr><td>Email</td><td>Low</td><td>Low</td><td>High reliability required</td><td>Low</td></tr>
+<tr><td>Web browsing</td><td>Medium</td><td>Low to medium</td><td>High reliability required</td><td>Medium</td></tr>
+<tr><td>Software download</td><td>Low</td><td>High</td><td>High reliability required</td><td>Low</td></tr>
+<tr><td>Video streaming</td><td>Medium</td><td>High</td><td>Moderate</td><td>High</td></tr>
+<tr><td>Audio call</td><td>Very high</td><td>Low to medium</td><td>Moderate</td><td>Very high</td></tr>
+<tr><td>Video call</td><td>Very high</td><td>High</td><td>Moderate</td><td>Very high</td></tr>
+</table>
+<h2>3. Routing Fundamentals: Hubs, Switches, Routers, VPN Paths, and the Layer Model</h2>
+<p>A hub repeats electrical signals to all connected ports and is largely obsolete. A switch forwards Ethernet frames based on MAC addresses and operates primarily at layer 2. A router forwards packets based on IP addressing and routing tables, interconnecting different networks. A VPN creates a logical path over an existing routed network; it does not replace routing but overlays a private forwarding domain on top of it.</p>
+<p>When discussing barriers, it is useful to distinguish physical forwarding from policy forwarding. Two packets may travel over the same physical links but receive very different treatment depending on protocol, port, or observed application behavior.</p>
+<h3>3.1 Why a layer model is useful</h3><p>Networking systems are easier to understand when they are divided into layers. Each layer has a limited responsibility and offers a service to the layer above it. This avoids having every application implement addressing, routing, retransmission, and naming completely on its own.</p><p>A layer model is not merely a teaching tool. It reflects how real systems are built: Ethernet or Wi-Fi move frames locally, IP routes packets across networks, TCP or UDP provide transport semantics, and application protocols such as HTTP or DNS give meaning to the exchanged data.</p><h3>3.2 Simplified Internet layer model</h3><table>
+<tr><th>Layer</th><th>Examples</th><th>Main responsibility</th></tr>
+<tr><td>Application layer</td><td>HTTP, HTTPS, DNS, WebSocket</td><td>Application meaning, commands, data format</td></tr>
+<tr><td>Transport layer</td><td>TCP, UDP, QUIC</td><td>Process-to-process communication, ports, reliability or datagrams</td></tr>
+<tr><td>Internet / network layer</td><td>IPv4, IPv6, ICMP</td><td>Addressing and routing across multiple networks</td></tr>
+<tr><td>Link layer</td><td>Ethernet, Wi-Fi, LTE, fiber access</td><td>Local frame transport on one physical or logical link</td></tr>
+</table><pre class="diagram">Application Layer   : HTTP, HTTPS, DNS, WebSocket
+Transport Layer     : TCP, UDP, QUIC
+Internet Layer      : IPv4, IPv6, ICMP
+Link Layer          : Ethernet, Wi-Fi, mobile access</pre><h3>3.3 Encapsulation</h3><p>Each layer wraps the data from the layer above it. For example, an HTTP request becomes TCP payload. That TCP segment becomes IP payload. The IP packet becomes payload inside a link-layer frame. At the receiving side, the reverse process happens: the frame is unpacked, then the IP packet, then the transport segment, and finally the application message.</p><pre class="diagram">HTTP request
+   inside TCP segment
+      inside IP packet
+         inside Ethernet / Wi-Fi frame</pre><h2>4. Modern Internet Barriers</h2>
+<h3>4.1 IPv4 and IPv6 asymmetry</h3>
+<p>Some providers offer only IPv4, some only IPv6, and some provide both through dual stack. A host behind an IPv6-only mobile carrier may have difficulty reaching services or peers that are reachable only via IPv4 unless translation or proxying is available.</p>
+<h3>4.2 NAT and carrier-grade NAT</h3>
+<p>NAT devices map internal private addresses to shared public addresses. They are efficient for address conservation but are hostile to unsolicited inbound connections. Carrier-grade NAT extends this behavior into provider networks, making direct peer-to-peer connectivity even harder.</p>
+<h3>4.3 Deep packet inspection and policy control</h3>
+<p>Middleboxes may inspect traffic content, application behavior, DNS patterns, or TLS metadata to classify and regulate traffic. These devices can block, delay, or degrade selected applications.</p>
+<h3>4.4 GeoIP blocking</h3>
+<p>Many services restrict access based on source IP location. Even technically valid connections can be rejected for policy reasons unrelated to transport viability.</p>
+<h3>4.5 Artificial throttling</h3>
+<p>Some networks degrade selected traffic by injecting additional delay, imposing rate limits, or triggering packet loss. Even small artificial loss rates can severely reduce TCP performance.</p>
+<pre class="diagram">User A  ----restricted path----  User B
+         [NAT] [filter] [throttle] [GeoIP] [DPI]</pre>
+<h3>4.6 Where barriers act in the layer model</h3><p>Different barriers affect different layers. A switch usually does not care whether the payload is HTTP or VPN traffic. A firewall may care about IP addresses and TCP or UDP ports. A deep packet inspection device may inspect up into TLS metadata, DNS contents, or HTTP headers. NAT changes addressing information between the local and Internet layers. Traffic shaping may observe either transport behavior or higher-layer patterns.</p><table>
+<tr><th>Barrier type</th><th>Typical layer of action</th><th>Example effect</th></tr>
+<tr><td>NAT</td><td>Between transport and network semantics</td><td>Rewrites source address and port</td></tr>
+<tr><td>Firewall rules</td><td>Network / transport layer</td><td>Blocks inbound TCP on selected ports</td></tr>
+<tr><td>DPI</td><td>Transport and application layers</td><td>Classifies HTTPS, DNS, or streaming traffic</td></tr>
+<tr><td>GeoIP filtering</td><td>Application / policy layer</td><td>Refuses service based on source region</td></tr>
+<tr><td>Throttling</td><td>Transport or application-observed behavior</td><td>Increases loss, latency, or rate limits</td></tr>
+</table><h2>5. Internet Protocol (IP)</h2>
+<p>IP is the network-layer protocol responsible for addressing and routing packets across interconnected networks. IPv4 uses 32-bit addresses. IPv6 uses 128-bit addresses. IP itself offers best-effort delivery: packets may be lost, duplicated, reordered, delayed, or fragmented.</p>
+<h3>5.1 IPv4 header fields</h3>
+<table>
+<tr><th>Field</th><th>Purpose</th></tr>
+<tr><td>Version</td><td>Identifies IPv4 or IPv6</td></tr>
+<tr><td>IHL</td><td>Internet Header Length</td></tr>
+<tr><td>DSCP/ECN</td><td>Quality of service and congestion signaling</td></tr>
+<tr><td>Total Length</td><td>Total packet length</td></tr>
+<tr><td>Identification</td><td>Used for fragmentation / reassembly</td></tr>
+<tr><td>Flags / Fragment Offset</td><td>Fragmentation control</td></tr>
+<tr><td>TTL</td><td>Limits lifetime across routers</td></tr>
+<tr><td>Protocol</td><td>Indicates TCP, UDP, ICMP, etc.</td></tr>
+<tr><td>Header Checksum</td><td>Protects IPv4 header integrity</td></tr>
+<tr><td>Source / Destination Address</td><td>Endpoint addressing</td></tr>
+</table>
+<pre class="diagram">+---------+-----+-----------+--------------+
+| Version | IHL | DSCP/ECN  | Total Length |
++---------+-----+-----------+--------------+
+| Identification | Flags | Fragment Offset|
++------------------------------------------+
+| TTL | Protocol | Header Checksum         |
++------------------------------------------+
+| Source Address                           |
++------------------------------------------+
+| Destination Address                      |
++------------------------------------------+</pre>
+<h2>6. ICMP Protocol</h2>
+<p>ICMP stands for <strong>Internet Control Message Protocol</strong>. It is part of the IP family and is used for control, diagnostics, and error reporting. Unlike TCP or UDP, ICMP is generally not used to carry ordinary application data. Instead, it helps hosts and routers communicate information about network conditions and delivery problems.</p>
+<h3>6.1 Purpose of ICMP</h3>
+<p>ICMP messages are used when something noteworthy happens during packet forwarding or delivery. Typical examples include destination unreachable, port unreachable, time exceeded, echo request and echo reply, and fragmentation needed.</p>
+<h3>6.2 Common ICMP message types</h3>
+<table>
+<tr><th>ICMP message</th><th>Meaning</th><th>Common use</th></tr>
+<tr><td>Echo Request / Echo Reply</td><td>Basic reachability test</td><td>Used by ping</td></tr>
+<tr><td>Destination Unreachable</td><td>Packet could not be delivered</td><td>Route failure, blocked host, closed UDP port</td></tr>
+<tr><td>Time Exceeded</td><td>TTL reached zero</td><td>Used by traceroute</td></tr>
+<tr><td>Fragmentation Needed</td><td>Packet too large for next hop and cannot be fragmented</td><td>Path MTU discovery</td></tr>
+</table>
+<p>Many networks filter ICMP at least partially. They may block echo requests, rate-limit replies, or suppress selected ICMP error messages. Therefore the overlay protocol should not rely exclusively on ICMP for liveness or fault detection.</p>
+<h2>7. UDP Protocol</h2>
+<p>UDP is a minimal transport protocol. It provides source and destination ports, a length field, and a checksum. It does not provide connection establishment, guaranteed delivery, ordering, congestion control, or flow control. Applications use UDP when they need either very low overhead or freedom to define their own transport behavior.</p>
+<table>
+<tr><th>UDP Header Field</th><th>Meaning</th></tr>
+<tr><td>Source Port</td><td>Sender-side application port</td></tr>
+<tr><td>Destination Port</td><td>Receiver-side application port</td></tr>
+<tr><td>Length</td><td>UDP header plus payload length</td></tr>
+<tr><td>Checksum</td><td>Error detection over pseudo-header, header, and payload</td></tr>
+</table>
+<h3>7.1 Uninterfered UDP transmission example</h3>
+<pre>Sender:    U1 ----&gt; U2 ----&gt; U3 ----&gt; U4
+Receiver:  U1       U2       U3       U4</pre>
+<h3>7.2 Packet loss and reordering example</h3>
+<pre>Sender:    U1 ----&gt; U2 ----&gt; U3 ----&gt; U4
+Network:           [lost]           [delayed]
+Receiver:  U1       U3       U4       U2</pre>
+<p>The receiver gets no built-in explanation from UDP itself. If recovery matters, the application must implement sequence numbers, acknowledgments, or forward error correction.</p>
+<h3>7.3 ICMP and closed ports</h3>
+<p>As explained in the ICMP section above, UDP itself does not provide a connection-refused message. However, if a UDP datagram reaches a host where no application is listening on the destination port, the host may send back an ICMP Port Unreachable message. In practice this can help a sender conclude that the remote UDP port is closed, although some networks filter such ICMP messages and therefore hide that information.</p>
+<h2>8. TCP Protocol</h2>
+<p>TCP provides a reliable, ordered byte stream. It establishes a connection using a three-way handshake and maintains sequence numbers, acknowledgments, retransmission timers, a receive window for flow control, and a congestion window for congestion control.</p>
+<h3>8.1 TCP header fields</h3>
+<table>
+<tr><th>Field</th><th>Purpose</th></tr>
+<tr><td>Source Port / Destination Port</td><td>Identify communicating applications</td></tr>
+<tr><td>Sequence Number</td><td>Byte position of first data byte in segment</td></tr>
+<tr><td>Acknowledgment Number</td><td>Next byte expected from peer</td></tr>
+<tr><td>Flags</td><td>SYN, ACK, FIN, RST and others</td></tr>
+<tr><td>Window Size</td><td>Advertised receive capacity</td></tr>
+<tr><td>Checksum</td><td>Error detection</td></tr>
+</table>
+<h3>8.2 TCP handshake</h3>
+<pre class="diagram">Client                               Server
+  SYN, seq=x   ---------------------&gt;
+                &lt;-------------------  SYN+ACK, seq=y, ack=x+1
+  ACK, ack=y+1 ---------------------&gt;</pre>
+<h3>8.3 TCP packet loss example</h3>
+<pre>Sender sends:  S1  S2  S3  S4
+Network loses:     S2
+Receiver sees: S1      S3  S4
+Receiver acks next expected byte for S2 repeatedly
+Sender retransmits S2</pre>
+<h2>9. TCP Congestion Control</h2>
+<p>Congestion control exists because the Internet is a shared resource. If every sender transmitted as fast as possible without restraint, routers would overflow their queues, drop packets, and the network could enter congestion collapse. TCP therefore tries to infer path capacity and current congestion state from acknowledgments, delay, and loss signals.</p>
+<h3>9.1 Core variables</h3>
+<p>TCP commonly uses two important limits: the <strong>receive window</strong>, which comes from the receiver and represents buffer availability, and the <strong>congestion window (cwnd)</strong>, which comes from the sender's estimate of safe network occupancy. The amount of outstanding unacknowledged data is bounded by the minimum of these two limits.</p>
+<pre>in_flight &lt;= min(receive_window, congestion_window)</pre>
+<h3>9.2 Slow start</h3>
+<p>TCP begins cautiously. It starts with a relatively small congestion window and increases rapidly as acknowledgments arrive. Historically this growth was one segment per acknowledgment round, producing approximately exponential growth per round-trip time.</p>
+<pre>RTT 1: cwnd = 1
+RTT 2: cwnd = 2
+RTT 3: cwnd = 4
+RTT 4: cwnd = 8
+RTT 5: cwnd = 16</pre>
+<h3>9.3 Congestion avoidance</h3>
+<p>After reaching a threshold called <code>ssthresh</code>, TCP usually transitions to slower, approximately linear growth. This reduces the risk of overshooting path capacity too aggressively.</p>
+<h3>9.4 Fast retransmit and fast recovery</h3>
+<p>If a segment is lost but later segments arrive, the receiver keeps acknowledging the last contiguous byte range received. Repeated duplicate ACKs signal a likely hole in the sequence space. Classical TCP Reno uses three duplicate ACKs as the trigger for fast retransmit.</p>
+<pre>Sent: 1 2 3 4 5
+Lost:   2
+ACKs: ack(2 expected), ack(2 expected), ack(2 expected)
+Action: retransmit missing segment immediately</pre>
+<h3>9.5 Congestion response</h3>
+<p>Loss is treated as evidence of congestion. Traditional algorithms cut the congestion window, often roughly in half, and continue probing from the reduced rate. Timeout-based loss is treated more severely than duplicate-ACK loss because it suggests a more serious path problem.</p>
+<h3>9.6 Reno, CUBIC, and BBR</h3>
+<p>Reno grows and halves the window using classic additive-increase / multiplicative-decrease behavior. CUBIC uses a cubic growth function that performs better on long-fat networks with large bandwidth-delay products. BBR estimates bottleneck bandwidth and minimum RTT directly and attempts to pace at the estimated delivery rate rather than waiting for packet loss as the main signal.</p>
+<h3>9.7 Why even small packet loss matters</h3>
+<p>A small artificial loss rate can drastically reduce TCP throughput because every loss event causes retransmissions, possible fast recovery, or full timeout. On a path where throttling intentionally introduces rare packet drops, TCP may repeatedly collapse its sending window.</p>
+<h2>10. TCP Backpressure and Flow Control</h2>
+<p>Backpressure is the receiver-driven mechanism that prevents a fast sender from overwhelming a slower receiver. This is distinct from congestion control. Congestion control protects the network. Flow control protects the endpoint.</p>
+<h3>10.1 Receive window</h3>
+<p>The receiver advertises how much free buffer space it currently has. If the receiving application processes data slowly, the available window shrinks.</p>
+<pre>Receiver buffer total: 64 KB
+Buffered but unread:   48 KB
+Advertised window:     16 KB</pre>
+<h3>10.2 Zero-window scenario</h3>
+<p>If the buffer fills completely, the receiver advertises a zero window. The sender must stop sending further data, except for occasional probes to determine whether the window has opened again.</p>
+<pre class="diagram">Sender ---------------------- data ---------------------&gt; Receiver
+Sender &lt;---------------- ACK, Window=0 ----------------- Receiver
+Sender pauses
+Sender ------------------ window probe ----------------&gt; Receiver
+Sender &lt;---------------- ACK, Window=32768 ------------- Receiver</pre>
+<h3>10.3 Why backpressure is needed</h3>
+<p>Without it, a fast sender could continue transmitting into a receiver whose application is blocked or slow, causing memory growth or packet discard. Backpressure is therefore a fundamental stability mechanism for reliable stream protocols.</p>
+<h2>11. QUIC Protocol</h2>
+<p>QUIC is a modern transport protocol built over UDP. It provides encryption, reliable delivery, stream multiplexing, congestion control, and low-latency connection establishment. Conceptually, it offers many transport functions similar to TCP, but with important architectural differences.</p>
+<h3>11.1 Main differences from TCP</h3>
+<table>
+<tr><th>Aspect</th><th>TCP</th><th>QUIC</th></tr>
+<tr><td>Implementation location</td><td>Mainly kernel transport stack</td><td>Typically user-space library</td></tr>
+<tr><td>Encryption</td><td>Optional via TLS layered above TCP</td><td>Integrated and mandatory</td></tr>
+<tr><td>Streams</td><td>Single ordered byte stream per connection</td><td>Multiple independent streams per connection</td></tr>
+<tr><td>Head-of-line blocking</td><td>Applies to all data in connection</td><td>Limited to affected stream data</td></tr>
+<tr><td>Retransmission unit</td><td>Byte ranges / segments</td><td>Frames resent in new packets</td></tr>
+</table>
+<h3>11.2 QUIC and packet loss</h3>
+<p>QUIC assigns packet numbers to packets and acknowledges received packets. When a packet is declared lost, QUIC does not literally reuse the same packet number. Instead, the lost information is re-encoded into a new packet with a new packet number. This matters because QUIC reasons about frames and stream data, not only raw packet identity.</p>
+<h3>11.3 How QUIC differs from TCP under loss</h3>
+<p>In TCP, if segment 2 is missing, later data is held back from the application because the transport delivers one ordered byte stream. In QUIC, if stream 5 loses a frame, stream 7 can still continue because streams are independently reassembled. Thus QUIC reduces transport-level head-of-line blocking across application streams.</p>
+<h3>11.4 QUIC congestion control</h3>
+<p>QUIC uses congestion control concepts broadly similar to TCP and commonly employs algorithms such as CUBIC or BBR. The difference is not that QUIC ignores congestion control; the difference is that QUIC can evolve faster in user space and integrate loss detection, packet pacing, and handshake behavior more tightly with the encrypted transport machinery.</p>
+<h3>11.5 QUIC loss example</h3>
+<pre>Sent packets:   P1  P2  P3  P4
+Loss:               P2
+ACKs received:  P1      P3  P4
+Sender infers P2 lost
+Sender sends P5 containing retransmitted frame data from P2</pre>
+<h2>12. DNS Protocol</h2>
+<p>DNS maps human-readable names to addresses and other resource records. A browser cannot reach <code>example.org</code> until some resolver returns one or more IP addresses. DNS can therefore become a barrier point: if the answers are modified, suppressed, or filtered, connectivity fails even though the underlying path might otherwise work.</p>
+<h3>12.1 Basic DNS message contents</h3>
+<table>
+<tr><th>Field Group</th><th>Meaning</th></tr>
+<tr><td>Transaction ID</td><td>Matches replies to queries</td></tr>
+<tr><td>Flags</td><td>Query/response, recursion, status bits</td></tr>
+<tr><td>Questions</td><td>Names and record types being requested</td></tr>
+<tr><td>Answers</td><td>Returned resource records</td></tr>
+<tr><td>Authority</td><td>Information about authoritative servers</td></tr>
+<tr><td>Additional</td><td>Supplementary records</td></tr>
+</table>
+<h3>12.2 DNS manipulation as a barrier</h3>
+<p>Operators can block or redirect by returning no answer, an invalid answer, or an answer pointing somewhere else. An overlay path combined with a trusted remote proxy can reduce dependence on a manipulated local DNS environment.</p>
+<h2>13. HTTP, HTTPS, and WebSockets</h2>
+<h3>13.1 HTTP</h3>
+<p>HTTP is a request-response protocol. A client sends a request line, headers, and optionally a body. The server returns a status line, headers, and a response body.</p>
+<pre>GET /index.html HTTP/1.1
+Host: example.com</pre>
+<h3>13.2 HTTPS</h3>
+<p>HTTPS is HTTP carried over TLS. TLS provides confidentiality, integrity, and server authentication. To an outside observer, the HTTP message body is hidden, though metadata may still reveal information.</p>
+<h3>13.3 WebSockets</h3>
+<p>WebSockets begin with an HTTP upgrade and then become a persistent, bidirectional application channel. They are useful for chat, dashboards, collaborative tools, and any browser application that benefits from server push without repeated polling.</p>
+<p>Motivation for WebSockets: classic HTTP was historically request-driven. Applications that needed ongoing bidirectional interaction either polled repeatedly or used workarounds. WebSockets provide a more natural long-lived channel.</p>
+<h2>14. Deep Packet Inspection and TLS Interception</h2>
+<p>Deep packet inspection systems attempt to classify traffic by looking beyond IP addresses and ports. They may inspect DNS, TLS handshakes, SNI values, certificate chains, HTTP headers, traffic timing, and sometimes application payloads where legally and technically possible.</p>
+<h3>14.1 Corporate TLS interception</h3>
+<p>In managed environments, an organization may install its own trusted root certificate onto client devices. The firewall or proxy can then terminate TLS from the client, inspect the decrypted traffic, and establish a separate TLS session to the destination service. From the browser's perspective, the forged certificate is trusted because the enterprise root has been installed locally.</p>
+<pre class="diagram">Browser --TLS1--&gt; Corporate Proxy --TLS2--&gt; Internet Server
+          decrypted here            re-encrypted here</pre>
+<p>This is functionally a controlled man-in-the-middle design.</p>
+<h2>15. VPNs, HTTP Proxies, and Tunneling</h2>
+<h3>15.1 VPNs</h3>
+<p>VPNs such as WireGuard and OpenVPN create tunnels between endpoints. They often prefer UDP as the outer transport because UDP allows the VPN to define its own retransmission, pacing, and loss-handling behavior, or to rely on higher layers where appropriate.</p>
+<h3>15.2 Why TCP-over-TCP is problematic</h3>
+<p>If a reliable TCP stream is carried inside another reliable TCP stream, both layers try to correct loss. The outer tunnel hides individual inner packets and presents only delayed or stalled delivery. The inner TCP sender then sees abnormal acknowledgment behavior and may also reduce its congestion window. This double reaction can amplify latency and reduce throughput severely.</p>
+<h3>15.3 Example TCP-over-TCP failure mode</h3>
+<pre>Inner TCP sends:     I1 I2 I3 I4
+Outer TCP carries:   T(I1) T(I2) T(I3) T(I4)
+Loss on outer path:        T(I2)
+Outer TCP retransmits T(I2) after delay
+Inner TCP sees ACK stall and may also infer congestion
+Both layers back off</pre>
+<h3>15.4 HTTP proxy concept</h3>
+<p>An HTTP proxy sits between the browser and the Internet. Instead of the browser connecting directly to many websites, it connects to the proxy. The proxy performs the remote connection on the browser's behalf. This is particularly useful when the browser-to-proxy leg can be transported through a protocol that survives the restrictive barrier more effectively.</p>
+<pre class="diagram">Browser --HTTP proxy config--&gt; Local Proxy ==overlay== Remote Proxy --&gt; Internet</pre>
+<h2>16. Why a UDP Overlay Helps</h2>
+<p>If the principal barrier lies between machine A and machine B, and if the barrier treats UDP differently from direct TCP application traffic, then a UDP overlay can create a more stable substrate for end-to-end communication. The overlay crosses the barrier as UDP, while the higher-level user traffic is reconstructed on the far side.</p>
+<p>Even when the ultimate application is TCP-based, using UDP as the outer carrier avoids TCP-over-TCP collapse. The overlay can recover loss at its own layer and present a cleaner transport service to the application or to a local proxy. When a browser is configured to use an HTTP proxy whose traffic is sent through the UDP overlay, the browser's many TCP sessions do not each directly experience the barrier's adverse behavior.</p>
+<h2>17. Overlay Architecture Overview</h2>
+<p>The Python implementation can be understood as a layered protocol stack over UDP. At the bottom is a liveness and RTT layer. Above that is a reliable datagram layer that detects loss and handles retransmission. Above that is the ChannelMux layer, which opens and closes multiple logical communication channels over the already-reliable substrate.</p>
+<pre class="diagram">Application / Proxy
+        |
+     ChannelMux
+        |
+Reliable DATA / CONTROL layer
+        |
+PING / PONG / RTT detection
+        |
+        UDP
+        |
+        IP</pre>
+<h2>18. Overlay Architecture Overview</h2>
+<p>The Python implementation can be understood as a layered protocol stack over UDP. At the bottom is a liveness and RTT layer. Above that is a reliable datagram layer that detects loss and handles retransmission. Above that is the ChannelMux layer, which opens and closes multiple logical communication channels over the already-reliable substrate.</p>
+<pre class="diagram">Application / Proxy
+        |
+     ChannelMux
+        |
+Reliable DATA / CONTROL layer
+        |
+PING / PONG / RTT detection
+        |
+        UDP
+        |
+        IP</pre>
+<h2>19. Layer 1: Connection Detection and RTT Measurement</h2>
+<p>Because UDP itself has no connection establishment, the overlay must detect whether the peer is alive and estimate round-trip time. A simple ping-pong exchange serves both purposes.</p>
+<h3>19.1 PING/PONG exchange</h3>
+<pre class="diagram">Peer A                                 Peer B
+PING(seq=100, ts=t0) --------------------&gt;
+                         &lt;---------------- PONG(seq=100)</pre>
+<p>When Peer A receives the matching PONG, it computes:</p>
+<pre>RTT_sample = t_receive - t_send</pre>
+<h3>19.2 Smoothed RTT</h3>
+<pre>SRTT   = (1 - alpha) * SRTT + alpha * RTT_sample
+RTTVAR = (1 - beta)  * RTTVAR + beta * |RTT_sample - SRTT|
+RTO    = SRTT + 4 * RTTVAR</pre>
+<h3>19.3 Uninterfered example</h3>
+<pre>t_send(PING)  = 10:00:00.000
+t_recv(PONG)  = 10:00:00.036
+RTT_sample    = 36 ms</pre>
+<h3>19.4 Loss example</h3>
+<pre>PING sent
+no PONG arrives before timeout
+peer suspected lost or path temporarily impaired
+new PING issued later or connection marked dead after threshold</pre>
+<h2>20. Layer 2: Reliable DATA / CONTROL Protocol</h2>
+<p>This layer compensates for UDP loss. It is responsible for identifying missing packets, requesting resends, acknowledging successful delivery, and ensuring the layer above sees a reliable ordered service.</p>
+<h3>20.1 DATA frames</h3>
+<p>DATA frames carry payload associated with a sequence number and channel identifier.</p>
+<pre>DATA(seq=201, channel=7, payload="...")</pre>
+<h3>20.2 ACK frames</h3>
+<p>ACK frames confirm reception of specific sequence numbers or contiguous received ranges, depending on implementation style.</p>
+<pre>ACK(seq=201)</pre>
+<h3>20.3 CONTROL frames</h3>
+<p>CONTROL frames request protocol actions such as resend.</p>
+<pre>CONTROL(RESEND, seq=202)</pre>
+<h3>20.4 Clean transmission example</h3>
+<pre class="diagram">Sender                                  Receiver
+DATA(201) ------------------------------&gt;
+DATA(202) ------------------------------&gt;
+DATA(203) ------------------------------&gt;
+                  &lt;---------------------- ACK(201)
+                  &lt;---------------------- ACK(202)
+                  &lt;---------------------- ACK(203)</pre>
+<h3>20.5 Packet loss example</h3>
+<pre class="diagram">Sender                                  Receiver
+DATA(301) ------------------------------&gt;
+DATA(302) --------X lost X--------------&gt;
+DATA(303) ------------------------------&gt;
+                  &lt;---------------------- ACK(301)
+                  &lt;---------------------- CONTROL(RESEND,302)
+DATA(302) retransmit -------------------&gt;
+                  &lt;---------------------- ACK(302)</pre>
+<p>At this layer, the systematic mitigation of packet loss happens. Therefore the layer above does not need to model packet loss as a first-class concern.</p>
+<h2>21. Layer 3: ChannelMux OPEN / DATA / CLOSE Protocol</h2>
+<p>ChannelMux establishes multiple logical channels over the already-reliable lower layer. Since the reliability layer below systematically mitigates packet loss, ChannelMux can assume frames arrive reliably enough for logical channel semantics.</p>
+<h3>21.1 OPEN</h3>
+<p>An OPEN frame creates a new logical channel.</p>
+<pre>OPEN(channel=5)</pre>
+<h3>21.2 DATA</h3>
+<p>Subsequent ChannelMux DATA frames carry stream payload for that channel.</p>
+<pre>DATA(channel=5, payload=...)</pre>
+<h3>21.3 CLOSE</h3>
+<p>A CLOSE frame terminates the logical channel.</p>
+<pre>CLOSE(channel=5)</pre>
+<p><strong>Important precision:</strong> there is no ACK on CLOSE at this layer.</p>
+<h3>21.4 Normal lifecycle example</h3>
+<pre class="diagram">OPEN(ch=5)
+DATA(ch=5, part1)
+DATA(ch=5, part2)
+CLOSE(ch=5)</pre>
+<p>Because loss recovery occurs below, Layer 3 is not where packet loss is discussed. The relevant place for loss and resend examples is Layer 2.</p>
+<h2>22. End-to-End Example: Browser via HTTP Proxy over Overlay</h2>
+<pre class="diagram">Browser
+  |
+  | TCP (browser to local proxy)
+  v
+Local HTTP Proxy
+  |
+  | ChannelMux OPEN/DATA/CLOSE over reliable overlay
+  v
+UDP Overlay Client ===== restricted barrier ===== UDP Overlay Server
+  |
+  v
+Remote HTTP Proxy
+  |
+  | TCP / TLS to websites
+  v
+Internet services</pre>
+<p>This configuration is often beneficial because the operating system and browser can use a normal HTTP proxy configuration, while the difficult segment across the barrier is carried as UDP overlay traffic. That avoids exposing each browser TCP connection directly to the barrier's hostile behavior.</p>
+<h2>23. Why This Can Improve Performance</h2>
+<p>Suppose the restrictive path introduces extra delay and occasional packet loss primarily harmful to TCP. If the browser directly opens many TCP sessions through that path, each session independently experiences slow start, loss-triggered backoff, and retransmission stalls. If instead the browser talks locally to a proxy and only the proxy traffic crosses the barrier through a carefully designed UDP overlay, the system can centralize recovery and avoid TCP-over-TCP effects.</p>
+<p>In other words, the application still benefits from reliable delivery where needed, but the hostile path no longer directly manipulates the application's TCP control loop in the same way.</p>
+<h2>24. Detailed TCP-over-TCP Problem Example</h2>
+<p>Consider an inner TCP connection carrying a file download through an outer TCP tunnel. The outer tunnel loses one carrier segment. The outer TCP stack retransmits it after a timeout or duplicate ACK processing. During the stall, the inner TCP sender receives delayed or missing acknowledgments and concludes that congestion may also have occurred. It shrinks its congestion window. After the outer tunnel finally recovers, the inner flow is still in a reduced state. Thus one loss event has been interpreted twice by two independent control loops.</p>
+<pre>Inner TCP bytes:      B1 B2 B3 B4 B5
+Outer TCP packets:    T1 T2 T3 T4 T5
+Loss on outer path:      T2
+Outer TCP: retransmits T2 later
+Inner TCP: observes ACK stall, may timeout or halve cwnd
+Result: both layers reduce rate</pre>
+<p>This is why TCP-over-UDP is usually preferred over TCP-over-TCP for tunnels.</p>
+<h2>25. Limitations and Engineering Considerations</h2>
+<p>A UDP overlay is not magic. It still competes for network resources and should behave responsibly. If it retransmits too aggressively without congestion awareness, it can worsen congestion. If it lacks authentication or encryption, it may be vulnerable to spoofing or inspection. If it assumes a stable path but NAT mappings expire quickly, it needs keepalives. If it uses too many outstanding packets, memory use grows.</p>
+<p>Thus the overlay solves one class of problems but introduces engineering responsibilities normally carried by mature transport protocols.</p>
+<h2>26. Development Procedure and Experience with AI-Supported Programming</h2>
+<p>This project was not only a technical networking exercise. It also served as a practical vehicle to gain experience with <strong>AI-supported software development</strong>.</p>
+<p>The development background of the author is rooted in decades of software engineering experience in the automotive environment, with strong familiarity in structured development according to the V-model and in implementation work mainly in the C programming language. In contrast, prior experience with Python was comparatively limited. This made the project particularly suitable as an experiment: it combined a technically demanding networking problem with a programming language and a development procedure that were intentionally less familiar.</p>
+<p>At the same time, the rise of artificial intelligence in recent years has created a major opportunity for industrial software development. AI-assisted programming promises substantial gains in speed, idea generation, debugging support, and rapid prototyping. However, access to such tools is not uniform across companies. In the author’s working environment at Bosch, modern external AI tools are generally not available to employees. One of the few accessible tools is <strong>Microsoft 365 Copilot</strong> inside Microsoft Teams.</p>
+<blockquote>“I’m M365 Copilot, based on the GPT 5 reasoning model.
+I’m optimized for Microsoft 365 workflows—e.g., drafting and formatting Word documents, building PowerPoint decks, analyzing data in Excel, and integrating with tools like SharePoint and Teams—while also handling general research, writing, and coding assistance.”</blockquote>
+<p>This environment imposes practical constraints. Input is limited to three files, and there are file type restrictions. Output is also restricted in size. For software development, this means that Copilot can often provide code snippets or, in favorable cases, complete source files, but the response length is limited, and file download behavior is not always reliable.</p>
+<h3>25.1 Project motivation as an AI-learning vehicle</h3>
+<p>The project therefore had a dual purpose: first, to solve a real technical networking problem, and second, to explore how AI-supported programming changes the software development procedure known from traditional engineering practice.</p>
+<p>As a sample project, a networking challenge was selected that was technically concrete, experimentally verifiable, and rich in implementation detail. Three computational nodes distributed world-wide were available, called A, B, and C. All were capable of running Python scripts. The tool <code>iperf</code> was used to investigate network behavior at the UDP packet level.</p>
+<p>The measurements showed a clear asymmetry. UDP communication between A and B worked well, with low latency and only the modest level of packet loss normally associated with UDP transport. UDP communication between A or B and C showed much worse behavior: latency was around 300 ms, and packet loss was around 20%, largely independent of bandwidth setting, whether 1 kB/s, 10 kB/s, or 100 kB/s. Packet loss from A or B toward C appeared to be worse than in the reverse direction.</p>
+<p>This was an important observation: the problem was not simply raw bandwidth exhaustion. It seemed to be a path characteristic or barrier effect acting largely independent of the sending rate. Under such circumstances, traditional reliable protocols such as TCP tend to suffer severely, because recovery and retransmission interact with congestion control and rapidly reduce useful throughput.</p>
+<p>The general problem can therefore be formulated as follows: <strong>How can a reliable connection be provided over an unreliable network path with high latency and substantial packet loss?</strong></p>
+<h3>25.2 Initial technical idea</h3>
+<p>The original communication scenario consisted of an application client on node C using an ephemeral source port and communicating directly over an unreliable path to an application server on node A listening on port 16666.</p>
+<p>The idea was to introduce a tunnel between the nodes. The tunnel itself would operate over the unreliable path and would include mechanisms to mitigate packet loss.</p>
+<p>Conceptually, the new structure became:</p>
+<ul>
+<li>the application client on C communicates reliably with a local tunnel endpoint,</li>
+<li>that tunnel endpoint communicates unreliably over UDP with the tunnel endpoint on A,</li>
+<li>and the tunnel endpoint on A communicates reliably with the application server on A.</li>
+</ul>
+<p>This structure made it possible to isolate the problematic wide-area network section and apply custom recovery logic exactly where it was needed.</p>
+<h3>25.3 First interaction with the AI tool</h3>
+<p>The development began with a very explicit prompt to M365 Copilot. The prompt described the UDP frame format, fixed frame length, a fixed byte prefix, an encoded payload length field, type indicators for single-frame and segmented payloads, server-side and client-side bridge behavior, and UDS-based test programs for generating and printing payloads.</p>
+<p>The result was immediate and remarkable: executable Python files were generated that implemented the requested bridge, client, server, and test setup in a form that was directly usable for experimentation. It was also straightforward to ask for additional support files such as a test harness, virtual network simulation, propagation delay simulation, packet drop simulation, PCAP generation, and Lua dissectors for Wireshark.</p>
+<p>One of the first key observations of the project was therefore that AI made it extremely easy to generate a complete working development environment around the core problem.</p>
+<h3>25.4 Early architectural restructuring</h3>
+<p>As the project grew, the implementation was separated into three main parts:</p>
+<ul>
+<li>a core Python file containing the bridge functionality itself, without command-line interaction or networking specifics,</li>
+<li>a runner file used in normal operation, including CLI, display logic, and connection to the networking layer,</li>
+<li>a test harness including virtual network behavior and test case management.</li>
+</ul>
+<p>This restructuring was important. It reflects a classic engineering principle that remains valid even under AI-supported development: architecture matters. AI can generate code quickly, but it does not guarantee long-term maintainability. Separating core logic, execution environment, and tests was therefore one of the key stabilizing measures.</p>
+<h3>25.5 Iterative development with AI sessions</h3>
+<p>The development then proceeded in repeated chat sessions with M365 Copilot. Since the tool accepted only three files, this architecture fit the tool constraints well: the core file, the runner file, and the test harness could be provided as context in each new session.</p>
+<p>A notable observation was that functional understanding by the tool was often surprisingly good. In many cases, the provided source code alone was enough for the AI to understand the intended behavior, without requiring an external formal specification. Analysis requests and change requests could be phrased directly in the prompt, and the tool frequently responded with relevant modifications.</p>
+<p>This led to a development style that differed significantly from traditional manual programming. Instead of continuously writing syntax by hand, the developer increasingly worked by describing intended behavior, reviewing generated code, executing tests, and formulating the next prompt.</p>
+<h3>25.6 Advantages observed</h3>
+<p>Several clear benefits of AI-supported programming became visible during the project.</p>
+<ul>
+<li><strong>Rapid generation of executable prototypes.</strong> Even the very first prompt produced working programs.</li>
+<li><strong>Fast generation of tooling around the core problem.</strong> The AI readily generated test harnesses, network simulation components, packet logging, PCAP generation, and Wireshark Lua support.</li>
+<li><strong>Effective support for diagnostics and debugging.</strong> Well-formulated prompts led to very useful diagnostics being added and to plausible root-cause analysis when code and traces were provided.</li>
+<li><strong>Speed of functional enrichment.</strong> Compared with traditional manual coding, AI made functional extension much faster, particularly in Python.</li>
+</ul>
+<h3>25.7 Limitations and failure modes observed</h3>
+<p>The project also revealed substantial limitations.</p>
+<p><strong>Output length and delivery constraints.</strong> As the files became longer, output became more difficult. In some cases, downloadable ZIP archives did not actually contain the intended changes even though the console output did. Arguing with the tool about this inconsistency was often unproductive; changing the prompting mode worked better.</p>
+<p><strong>Tendency to drop functionality in larger code bases.</strong> As the functional scope increased, M365 Copilot began to show a tendency to drop existing functionality, sometimes without clear motivation. In other cases, changes fixed one issue but silently removed something unrelated.</p>
+<p><strong>Generation of syntactically complex but non-working code.</strong> The project encountered code that did not run at all, mingled or inconsistent fragments, misspelled variable names, incomplete updates, and architectural side effects in unrelated places.</p>
+<p><strong>Limited solution space per prompt.</strong> Prompt wording strongly influenced the shape of the generated solution. Asking for “the updated script” often forced all fixes into one file, even when the correct solution required coordinated changes across multiple files.</p>
+<h3>25.8 Importance of testing</h3>
+<p>Testing proved essential throughout the project. Test cases generated evidence that a function really worked as intended and also helped to constrain the AI. A useful prompt pattern was not only to ask for a code change, but also to ask the tool to describe the stimulation, the expected result, and the observable success criteria.</p>
+<p>Regression testing was particularly important. Every AI-generated change carried the risk of collateral damage. It was dangerous to assume that a proposed change was complete, correct, or dependency-safe. Therefore, changes needed to be tested not only locally but against the broader behavior of the system.</p>
+<h3>25.9 Effective working rules derived from practice</h3>
+<ul>
+<li><strong>Use small iteration steps.</strong> Step-by-step changes were much safer than large transformations.</li>
+<li><strong>Limit the degree of freedom.</strong> Verbose and precise prompts worked best, especially for debugging.</li>
+<li><strong>Prefer patches over full rewrites.</strong> The larger the generated code block, the higher the chance of unintended changes.</li>
+<li><strong>Review architecture, not only syntax.</strong> Even plausible code must be checked for architectural fit.</li>
+<li><strong>Do not expect first-run success.</strong> AI-generated code is often executable, but not necessarily correct, complete, or robust.</li>
+<li><strong>Maintain refactoring cycles.</strong> Development should alternate between functional enrichment and refactoring.</li>
+</ul>
+<h3>25.10 Observed development speed</h3>
+<p>Despite the limitations, the acceleration was substantial. Within only a few working hours, it was possible to generate a functioning tunnel implementation, a test harness, diagnostic tools, and a more robust version of the code. The first tests on the distributed infrastructure with nodes A, B, and C were immediately successful.</p>
+<h3>25.11 Documentation experience and tool suitability</h3>
+<p>M365 Copilot was useful for coding assistance, but it was not well suited for generating meaningful technical documentation of the quality desired for this project. For documentation, the workflow was switched to <strong>ChatGPT 5.4 Thinking</strong>, which generated this documentation quickly and with comparatively few iterations.</p>
+<p>This suggests a broader practical conclusion: different AI tools may be better suited for different phases of engineering work. One tool may be useful for iterative coding assistance inside a constrained enterprise environment, while another may be much stronger in technical writing, synthesis, and document generation.</p>
+<h3>25.12 Final assessment</h3>
+<p>Overall, AI-supported programming proved to be a major productivity amplifier. It changed the software development procedure in a fundamental way. The developer no longer had to invest as much effort in low-level syntax production and could instead focus more on architecture, test strategy, diagnosis, review, and prompt formulation.</p>
+<p>However, this shift comes with a corresponding obligation: the developer must remain architect, reviewer, and verifier. AI delivers something like a rapid first 70% solution. It is fast, often impressive, and frequently executable. But it does not remove the need for engineering discipline. Incomplete change propagation, hidden regressions, architectural drift, and false confidence remain significant risks.</p>
+<p>Therefore the most effective use of AI in software development, at least in the context explored here, is neither blind trust nor full manual control. It is a disciplined hybrid process: use AI for speed, use architecture to preserve structure, use tests to prove behavior, and use human judgment to keep the system coherent.</p>
+<p><strong>Concluding remark:</strong> This project demonstrates that AI-supported programming can dramatically accelerate exploration, prototyping, and refinement of technically demanding software, even in unfamiliar implementation languages. At the same time, it confirms that classical engineering discipline—especially architecture, testing, controlled change scope, and refactoring—remains indispensable. AI changes the mechanics of development, but it does not eliminate the need for responsible software engineering.</p>
+<h2>27. Conclusion</h2>
+<p>The modern Internet often contains barriers that are invisible to casual users but decisive for protocol behavior: NAT, IPv4/IPv6 asymmetry, packet shaping, filtering, TLS interception, DNS manipulation, and selective degradation. UDP overlays are valuable because they let developers reconstruct a transport substrate suited to the actual environment.</p>
+<p>The described Python design is especially interesting because it clearly separates concerns into three layers: RTT and liveness detection, reliable DATA / CONTROL framing for loss mitigation, and ChannelMux OPEN / DATA / CLOSE semantics above that reliable base. Because packet loss is systematically handled below ChannelMux, the logical channel layer remains simpler and more precise.</p>
+<p>Used together with an HTTP proxy, the overlay can improve survivability and often performance across restrictive barriers, while avoiding the classic TCP-over-TCP failure mode.</p>
+<h2>References</h2>
+<ol>
+<li>RFC 768 — User Datagram Protocol.</li>
+<li>RFC 791 — Internet Protocol.</li>
+<li>RFC 793 — Transmission Control Protocol.</li>
+<li>RFC 1035 — Domain Names - Implementation and Specification.</li>
+<li>RFC 9000 — QUIC: A UDP-Based Multiplexed and Secure Transport.</li>
+<li>RFC 9110 — HTTP Semantics.</li>
+<li>WireGuard documentation.</li>
+</ol>
+</div></body></html>

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -3737,7 +3737,7 @@ class WebSocketSession(ISession):
       KIND=0x02 -> PONG (payload: Q echo_tx_ns)
 
     Features:
-      - Client mode (proactive connect) and Server mode (accept exactly one overlay peer)
+      - Client mode (proactive connect) and Server mode (accept multiple overlay peers)
       - Auto-reconnect (client) with backoff
       - RTT estimation via StreamRTT/StreamRTTRuntime (drives overlay 'connected')
       - Per-connection counters + running CRC32 over wire bytes (KIND+payload)
@@ -3747,6 +3747,7 @@ class WebSocketSession(ISession):
     _K_APP  = 0x00
     _K_PING = 0x01
     _K_PONG = 0x02
+    _MUX_HDR = struct.Struct(">HBHBH")
     _PAYLOAD_CODECS = {
         WebSocketBinaryPayloadCodec.mode: WebSocketBinaryPayloadCodec,
         WebSocketBase64PayloadCodec.mode: WebSocketBase64PayloadCodec,
@@ -3863,6 +3864,13 @@ class WebSocketSession(ISession):
         self._reconnect_task: Optional[asyncio.Task] = None
         self._disconnect_task: Optional[asyncio.Task] = None
         self._tx_queue: "asyncio.Queue[tuple[bytes, Optional[Callable[[], None]]]]" = asyncio.Queue()
+        self._server_connected_evt = asyncio.Event()
+        self._server_peers: Dict[int, dict] = {}
+        self._server_peer_by_ws_id: Dict[int, int] = {}
+        self._server_next_peer_id: int = 1
+        self._server_chan_to_peer: Dict[int, Tuple[int, int]] = {}
+        self._server_peer_chan_to_mux: Dict[Tuple[int, int], int] = {}
+        self._server_next_mux_chan: int = 1
 
         # Early buffer (APP/CTRL frames preserved as individual WS messages)
         self._early_buf: Deque[bytes] = deque()
@@ -3903,7 +3911,8 @@ class WebSocketSession(ISession):
         self._run_flag = True
 
         # Attach RTT driver (send function gets attached when WS is up)
-        self._rtt_rt.attach(send_ping_fn=None, on_state_change=self._on_rtt_state_change)
+        if self._peer_tuple:
+            self._rtt_rt.attach(send_ping_fn=None, on_state_change=self._on_rtt_state_change)
 
         if self._peer_tuple:
             # CLIENT
@@ -3924,7 +3933,8 @@ class WebSocketSession(ISession):
         self._log.info(f"[WS-SESSION] ({self._probe_id}) stopping")
         self._run_flag = False
 
-        self._rtt_rt.detach()
+        if self._peer_tuple:
+            self._rtt_rt.detach()
 
         for t in (self._connecting_task, self._reconnect_task):
             if t: t.cancel()
@@ -3950,6 +3960,10 @@ class WebSocketSession(ISession):
             pass
         self._ws = None
 
+        for peer_id in list(self._server_peers.keys()):
+            await self._close_server_peer(peer_id)
+        self._server_connected_evt.clear()
+
         try:
             if self._server:
                 self._server.close()             # type: ignore
@@ -3961,9 +3975,19 @@ class WebSocketSession(ISession):
         self._set_overlay_connected(False)
 
     async def wait_connected(self, timeout: Optional[float] = None) -> bool:
+        if not self._peer_tuple:
+            if self._server_peers:
+                return True
+            try:
+                await asyncio.wait_for(self._server_connected_evt.wait(), timeout)
+                return True
+            except asyncio.TimeoutError:
+                return False
         return await self._rtt_rt.wait_connected(timeout)
 
     def is_connected(self) -> bool:
+        if not self._peer_tuple:
+            return bool(self._server_peers)
         return self._rtt.is_connected()
 
     def get_metrics(self) -> SessionMetrics:
@@ -3983,6 +4007,22 @@ class WebSocketSession(ISession):
             return 0
         wire = bytes([self._K_APP]) + payload
 
+        if not self._peer_tuple:
+            if not self._server_peers and self._ws is not None:
+                self._schedule_send(wire, on_sent=lambda: self._notify_peer_tx(len(wire)))
+                return len(payload)
+            routed = self._server_rewrite_outbound_app(payload)
+            if routed is None:
+                self._log.debug(f"[WS/TX] ({self._probe_id}) drop unroutable server APP len={len(payload)}")
+                return 0
+            peer_id, payload = routed
+            ctx = self._server_peers.get(peer_id)
+            if not ctx:
+                self._log.debug(f"[WS/TX] ({self._probe_id}) drop APP for missing peer_id={peer_id}")
+                return 0
+            self._schedule_server_send(ctx, bytes([self._K_APP]) + payload, on_sent=lambda: self._notify_peer_tx(len(payload) + 1))
+            return len(payload)
+
         if self._ws is None:
             self._buffer_early(wire)
             self._log.debug(f"[WS/TX] ({self._probe_id}) early-buffer APP bytes={len(wire)} buf={len(self._early_buf)}")
@@ -3992,6 +4032,79 @@ class WebSocketSession(ISession):
 
         self._schedule_send(wire, on_sent=lambda: self._notify_peer_tx(len(wire)))
         return len(payload)
+
+    def _alloc_server_peer_id(self) -> int:
+        peer_id = self._server_next_peer_id
+        while peer_id in self._server_peers:
+            peer_id += 1
+            if peer_id > 0xFFFF:
+                peer_id = 1
+        self._server_next_peer_id = 1 if peer_id >= 0xFFFF else (peer_id + 1)
+        return peer_id
+
+    def _alloc_server_mux_chan(self) -> int:
+        chan = self._server_next_mux_chan
+        while chan in self._server_chan_to_peer:
+            chan += 1
+            if chan > 0xFFFF:
+                chan = 1
+        self._server_next_mux_chan = 1 if chan >= 0xFFFF else (chan + 1)
+        return chan
+
+    def _rewrite_mux_chan_id(self, payload: bytes, new_chan: int) -> bytes:
+        if len(payload) < self._MUX_HDR.size:
+            return payload
+        _, proto, counter, mtype, dlen = self._MUX_HDR.unpack(payload[:self._MUX_HDR.size])
+        if len(payload) < self._MUX_HDR.size + dlen:
+            return payload
+        return self._MUX_HDR.pack(new_chan, proto, counter, mtype, dlen) + payload[self._MUX_HDR.size:self._MUX_HDR.size + dlen]
+
+    def _server_rewrite_inbound_app(self, peer_id: int, payload: bytes) -> bytes:
+        if len(payload) < self._MUX_HDR.size:
+            return payload
+        try:
+            peer_chan, _proto, _counter, _mtype, dlen = self._MUX_HDR.unpack(payload[:self._MUX_HDR.size])
+        except Exception:
+            return payload
+        if len(payload) < self._MUX_HDR.size + dlen:
+            return payload
+        key = (peer_id, peer_chan)
+        mux_chan = self._server_peer_chan_to_mux.get(key)
+        if mux_chan is None:
+            mux_chan = self._alloc_server_mux_chan()
+            self._server_peer_chan_to_mux[key] = mux_chan
+            self._server_chan_to_peer[mux_chan] = key
+        return self._rewrite_mux_chan_id(payload, mux_chan)
+
+    def _server_rewrite_outbound_app(self, payload: bytes) -> Optional[Tuple[int, bytes]]:
+        if len(payload) < self._MUX_HDR.size:
+            return None
+        try:
+            mux_chan, _proto, _counter, _mtype, dlen = self._MUX_HDR.unpack(payload[:self._MUX_HDR.size])
+        except Exception:
+            return None
+        if len(payload) < self._MUX_HDR.size + dlen:
+            return None
+        mapped = self._server_chan_to_peer.get(mux_chan)
+        if mapped is None:
+            return None
+        peer_id, peer_chan = mapped
+        return peer_id, self._rewrite_mux_chan_id(payload, peer_chan)
+
+    def _server_unregister_peer_channels(self, peer_id: int) -> None:
+        for key, mux_chan in list(self._server_peer_chan_to_mux.items()):
+            if key[0] != peer_id:
+                continue
+            self._server_peer_chan_to_mux.pop(key, None)
+            self._server_chan_to_peer.pop(mux_chan, None)
+
+    def _update_server_overlay_connected(self) -> None:
+        connected = bool(self._server_peers)
+        if connected:
+            self._server_connected_evt.set()
+        else:
+            self._server_connected_evt.clear()
+        self._set_overlay_connected(connected)
 
     # ---- Internals ------------------------------------------------------------
 
@@ -4430,7 +4543,6 @@ class WebSocketSession(ISession):
             path = getattr(ws, "path", getattr(getattr(ws, "request", None), "path", self._ws_path))
             self._log.debug(f"[WS-SESSION] ({self._probe_id}) HTTP path={path}")
 
-            # Only one overlay peer at a time: replace previous if any
             await self._on_accept(ws)
             # IMPORTANT: keep handler alive; otherwise server will close with 1000
             try:
@@ -4487,7 +4599,39 @@ class WebSocketSession(ISession):
                 delay = min(delay * 2.0, 10.0)
         self._reconnect_task = self._loop.create_task(_reconnect())  # type: ignore
 
-    async def _on_accept(self, ws) -> None:        
+    async def _on_accept(self, ws) -> None:
+        if not self._peer_tuple:
+            peer_id = self._alloc_server_peer_id()
+            ctx = {
+                "peer_id": peer_id,
+                "ws": ws,
+                "tx_queue": asyncio.Queue(),
+                "tx_task": None,
+                "rx_task": None,
+            }
+            self._server_peers[peer_id] = ctx
+            self._server_peer_by_ws_id[id(ws)] = peer_id
+            self._configure_ws_socket(ws)
+            peer = getattr(ws, "remote_address", None)
+            sockname = getattr(ws, "local_address", None)
+            self._log.info(f"[WS-SESSION] ({self._probe_id}) accept: peer_id={peer_id} local={sockname} peer={peer}")
+            try:
+                if isinstance(peer, tuple) and len(peer) >= 2:
+                    self._peer_host, self._peer_port = peer[0], int(peer[1])
+            except Exception:
+                pass
+            self._reset_counters()
+            self._ensure_server_tx_task(ctx)
+            ctx["rx_task"] = self._loop.create_task(self._rx_pump(ws=ws, peer_id=peer_id))  # type: ignore
+            self._ws = ws
+            self._rx_task = ctx["rx_task"]
+            self._tx_task = ctx.get("tx_task")
+            self._update_server_overlay_connected()
+            if callable(self._on_peer_set_cb):
+                try: self._on_peer_set_cb(self._peer_host, self._peer_port)
+                except Exception: pass
+            return
+
         try:
             if self._ws:
                 await self._ws.close()
@@ -4519,6 +4663,28 @@ class WebSocketSession(ISession):
         if callable(self._on_peer_set_cb):
             try: self._on_peer_set_cb(self._peer_host, self._peer_port)
             except Exception: pass
+
+    async def _close_server_peer(self, peer_id: int) -> None:
+        ctx = self._server_peers.pop(peer_id, None)
+        if not ctx:
+            return
+        self._server_peer_by_ws_id.pop(id(ctx.get("ws")), None)
+        self._server_unregister_peer_channels(peer_id)
+        tx_task = ctx.get("tx_task")
+        if tx_task:
+            tx_task.cancel()
+        rx_task = ctx.get("rx_task")
+        if rx_task and rx_task is not asyncio.current_task():
+            rx_task.cancel()
+        ws = ctx.get("ws")
+        if self._ws is ws:
+            self._ws = None
+        if ws is not None:
+            try:
+                await ws.close()
+            except Exception:
+                pass
+        self._update_server_overlay_connected()
 
     async def _connect_to(self, host: str, port: int) -> None:
         if not self._run_flag:
@@ -4687,11 +4853,56 @@ class WebSocketSession(ISession):
 
         self._tx_task = self._loop.create_task(_tx_loop())  # type: ignore
 
+    def _ensure_server_tx_task(self, ctx: dict) -> None:
+        if ctx.get("tx_task") is not None or not ctx.get("ws"):
+            return
+
+        async def _tx_loop():
+            q = ctx["tx_queue"]
+            try:
+                while True:
+                    wire, on_sent = await q.get()
+                    ws = ctx.get("ws")
+                    try:
+                        if ws is None:
+                            continue
+                        send_coro = ws.send(self._ws_payload_codec.encode(wire))
+                        if self._ws_send_timeout_s > 0:
+                            await asyncio.wait_for(send_coro, timeout=self._ws_send_timeout_s)
+                        else:
+                            await send_coro
+                        self._bump_tx(wire)
+                        if callable(on_sent):
+                            try:
+                                on_sent()
+                            except Exception:
+                                pass
+                    except asyncio.TimeoutError:
+                        self._log.warning(
+                            f"[WS/TX] ({self._probe_id}) server peer_id={ctx['peer_id']} send timeout after {self._ws_send_timeout_s:.3f}s; closing peer"
+                        )
+                        await self._close_server_peer(ctx["peer_id"])
+                        return
+                    except Exception as e:
+                        self._log.info(f"[WS/TX] ({self._probe_id}) server peer_id={ctx['peer_id']} send error: {e!r}")
+                    finally:
+                        q.task_done()
+            except asyncio.CancelledError:
+                return
+
+        ctx["tx_task"] = self._loop.create_task(_tx_loop())  # type: ignore
+
     def _schedule_send(self, wire: bytes, on_sent: Optional[Callable[[], None]] = None) -> None:
         if not self._ws:
             return
         self._ensure_tx_task()
         self._tx_queue.put_nowait((bytes(wire), on_sent))
+
+    def _schedule_server_send(self, ctx: dict, wire: bytes, on_sent: Optional[Callable[[], None]] = None) -> None:
+        if not ctx.get("ws"):
+            return
+        self._ensure_server_tx_task(ctx)
+        ctx["tx_queue"].put_nowait((bytes(wire), on_sent))
 
     def _configure_ws_socket(self, ws) -> None:
         try:
@@ -4866,6 +5077,8 @@ class WebSocketSession(ISession):
         """
         Called by StreamRTTRuntime. Sends a PING control frame if WS exists.
         """
+        if not self._peer_tuple:
+            return
         if not self._ws:
             return
 
@@ -4894,12 +5107,23 @@ class WebSocketSession(ISession):
         self._schedule_send(body, on_sent=lambda: self._notify_peer_tx(len(body)))
         self._log.debug(f"[WS/TX] ({self._probe_id}) PONG queued")
 
+    def _send_pong_frame_server(self, ctx: dict, echo_tx_ns: int) -> None:
+        body = bytes([self._K_PONG]) + self._rtt.build_pong_bytes(echo_tx_ns)
+        self._log.debug(f"[WS/GUARD] ({self._probe_id}) PONG tx peer_id={ctx['peer_id']}: echo_tx_ns={echo_tx_ns}")
+        self._schedule_server_send(ctx, body, on_sent=lambda: self._notify_peer_tx(len(body)))
+
     # --- RX pump ---------------------------------------------------------------
-    async def _rx_pump(self) -> None:
-        self._log.debug(f"[WS/RX] ({self._probe_id}) pump start")
+    async def _rx_pump(self, ws=None, peer_id: Optional[int] = None) -> None:
+        client_mode = self._peer_tuple is not None
+        active_ws = self._ws if ws is None else ws
+        ctx = self._server_peers.get(peer_id) if (not client_mode and peer_id is not None) else None
+        suffix = "" if peer_id is None else f" peer_id={peer_id}"
+        self._log.debug(f"[WS/RX] ({self._probe_id}) pump start{suffix}")
         try:
             while True:
-                msg = await self._ws.recv()  # type: ignore
+                if active_ws is None:
+                    return
+                msg = await active_ws.recv()  # type: ignore
                 b = self._decode_ws_message(msg)
                 if b is None:
                     continue
@@ -4915,6 +5139,8 @@ class WebSocketSession(ISession):
                 payload = b[1:]
 
                 if kind == self._K_APP:
+                    if not client_mode and peer_id is not None:
+                        payload = self._server_rewrite_inbound_app(peer_id, payload)
                     if self._on_app_from_peer_bytes:
                         try: self._on_app_from_peer_bytes(len(payload))
                         except Exception: pass
@@ -4930,16 +5156,19 @@ class WebSocketSession(ISession):
                         # Guard log: we received PING (both original tx_ns and echo_ns)
                         self._log.debug(f"[WS/GUARD] ({self._probe_id}) PING rx: tx_ns={tx_ns} echo_ns={echo_ns}")
 
-                        self._rtt.on_ping_received(tx_ns)
-                        if echo_ns:
-                            # Courtesy update
-                            self._rtt.on_pong_received(echo_ns)
-                        self._send_pong_frame(tx_ns)
+                        if client_mode:
+                            self._rtt.on_ping_received(tx_ns)
+                            if echo_ns:
+                                # Courtesy update
+                                self._rtt.on_pong_received(echo_ns)
+                            self._send_pong_frame(tx_ns)
+                        elif ctx is not None:
+                            self._send_pong_frame_server(ctx, tx_ns)
                     else:
                         self._log.debug(f"[WS/RX] ({self._probe_id}) malformed PING len={len(payload)}")
 
                 elif kind == self._K_PONG:
-                    if len(payload) >= 8:
+                    if client_mode and len(payload) >= 8:
                         (echo_tx_ns,) = struct.unpack(">Q", payload[:8])
 
                         # Take the sample before state flip for better logging
@@ -4956,7 +5185,8 @@ class WebSocketSession(ISession):
                         if now != was:
                             self._set_overlay_connected(now)
                     else:
-                        self._log.debug(f"[WS/RX] ({self._probe_id}) malformed PONG len={len(payload)}")
+                        if client_mode:
+                            self._log.debug(f"[WS/RX] ({self._probe_id}) malformed PONG len={len(payload)}")
 
                 else:
                     self._log.debug(f"[WS/RX] ({self._probe_id}) unknown KIND=0x{kind:02x} n={len(b)}")
@@ -4965,18 +5195,21 @@ class WebSocketSession(ISession):
             self._log.debug(f"[WS/RX] ({self._probe_id}) cancelled")
             return
         except Exception as e:
-            self._log.info(f"[WS/RX] ({self._probe_id}) pump error/close: {e!r}")
+            self._log.info(f"[WS/RX] ({self._probe_id}) pump error/close{suffix}: {e!r}")
         finally:
-            try:
-                if self._ws:
-                    await self._ws.close()   # type: ignore
-            except Exception:
-                pass
-            self._ws = None
-            self._schedule_overlay_disconnect()
-            if self._peer_tuple:
-                self._start_reconnect_loop()
-            self._log.debug(f"[WS/RX] ({self._probe_id}) pump stop")
+            if client_mode:
+                try:
+                    if self._ws:
+                        await self._ws.close()   # type: ignore
+                except Exception:
+                    pass
+                self._ws = None
+                self._schedule_overlay_disconnect()
+                if self._peer_tuple:
+                    self._start_reconnect_loop()
+            elif peer_id is not None:
+                await self._close_server_peer(peer_id)
+            self._log.debug(f"[WS/RX] ({self._probe_id}) pump stop{suffix}")
 
     # --- overlay state (RTT-driven) -------------------------------------------
     def _on_rtt_state_change(self, connected: bool) -> None:
@@ -4986,7 +5219,8 @@ class WebSocketSession(ISession):
         if self._overlay_connected == v:
             return
         self._overlay_connected = v
-        self._log.info(f"[WS-SESSION] ({self._probe_id}) overlay -> {'CONNECTED' if v else 'DISCONNECTED'} (RTT)")
+        mode = "RTT" if self._peer_tuple else "peer-count"
+        self._log.info(f"[WS-SESSION] ({self._probe_id}) overlay -> {'CONNECTED' if v else 'DISCONNECTED'} ({mode})")
         if v and callable(self._on_peer_set_cb):
             try: self._on_peer_set_cb(self._peer_host, self._peer_port)
             except Exception: pass
@@ -5198,8 +5432,9 @@ class ChannelMux:
         if not _has('--own-servers'):
             p.add_argument(
                 '--own-servers', nargs='*', default=None,
-                help=("Space-separated service specs: "
+                help=("Space-separated service specs (client mode only): "
                       "'proto,listen_port,listen_bind,proto,host,port' (quoted). "
+                      "Listener instances ignore --own-servers because multiple overlay peers make the target ambiguous. "
                       "Example: \"tcp,80,0.0.0.0,tcp,127.0.0.1,88 udp,16666,::,udp,127.0.0.1,16666\"")
             )
         # Keep backpressure knobs (apply to local TCP writers we own)
@@ -5220,6 +5455,14 @@ class ChannelMux:
         mux = ChannelMux(session, loop, on_local_rx_bytes, on_local_tx_bytes)
         # Parse catalog
         services = ChannelMux._parse_own_servers(getattr(args, 'own_servers', None))
+        listener_mode = not bool(getattr(args, 'peer', None))
+        if listener_mode and services:
+            mux.log.info(
+                "[MUX] listener mode detected: ignoring %d --own-servers entries; "
+                "the listening peer must not expose ambiguous local services when multiple overlay peers connect",
+                len(services),
+            )
+            services = []
         #if not services:
          #   raise ValueError("No services defined. Provide --own-servers \"proto,port,bind,proto,host,port ...\"")
         for s in services:
@@ -6978,6 +7221,33 @@ class StatsBoard:
         )
 
 # ============================================================================
+class RunnerMuxAggregate:
+    def __init__(self, muxes: List["ChannelMux"]):
+        self._muxes = list(muxes)
+
+    def udp_open_count(self) -> int:
+        return sum(m.udp_open_count() for m in self._muxes)
+
+    def tcp_open_count(self) -> int:
+        return sum(m.tcp_open_count() for m in self._muxes)
+
+    def snapshot_connections(self) -> dict:
+        udp_rows: list[dict] = []
+        tcp_rows: list[dict] = []
+        for mux in self._muxes:
+            snap = mux.snapshot_connections()
+            udp_rows.extend(snap.get("udp", []))
+            tcp_rows.extend(snap.get("tcp", []))
+        return {
+            "udp": udp_rows,
+            "tcp": tcp_rows,
+            "counts": {
+                "udp": len(udp_rows),
+                "tcp": len(tcp_rows),
+            },
+        }
+
+
 class Runner:
     """
     Thin orchestrator: wires ISession + ChannelMux + StatsBoard and manages lifecycle.
@@ -6990,6 +7260,8 @@ class Runner:
         self._stop = asyncio.Event()
         self._session_obj: Optional[ISession] = None
         self.mux: Optional["ChannelMux"] = None
+        self._sessions: List[ISession] = []
+        self._muxes: List["ChannelMux"] = []
         self.stats = StatsBoard(args )
         self.admin_web = None
         self._restart_requested = asyncio.Event()
@@ -7003,29 +7275,34 @@ class Runner:
         self.log.debug("[SERVER] Runner start on session id=%x", id(self))
 
         loop = asyncio.get_running_loop()
-        # 1) Build overlay session (myudp/tcp/quic/ws) and connect StatsBoard events
-        session = Runner.build_session_from_overlay(self.args)
-        session.set_on_state_change(self._on_state_change)
-        session.set_on_peer_rx(self.stats.on_peer_rx_bytes)
-        session.set_on_peer_tx(self.stats.on_peer_tx_bytes)
-        session.set_on_peer_set(self.stats.on_peer_set)
-        # Count peer->local bytes when app payload arrives from overlay
-        session.set_on_app_from_peer_bytes(self.stats.on_app_tx_bytes)
-        self._session_obj = session
-        self.stats.bind_session(self._session_obj)
-        
-        # 2) Create ChannelMux with local metering (local->peer)
-        self.mux = ChannelMux.from_args(
-            self._session_obj, 
-            loop, 
-            self.args,
-            on_local_rx_bytes=self.stats.on_app_rx_bytes,
-            on_local_tx_bytes=self.stats.on_app_tx_bytes
-        )
+        transport_sessions = Runner.build_sessions_from_overlay(self.args)
+        self._sessions = []
+        self._muxes = []
+        for transport_name, session in transport_sessions:
+            session.set_on_state_change(lambda connected, transport_name=transport_name, session=session: self._on_state_change(transport_name, session, connected))
+            session.set_on_peer_rx(self.stats.on_peer_rx_bytes)
+            session.set_on_peer_tx(self.stats.on_peer_tx_bytes)
+            session.set_on_peer_set(self.stats.on_peer_set)
+            session.set_on_app_from_peer_bytes(self.stats.on_app_tx_bytes)
 
-        # 3) Start session first, then mux
-        await self._session_obj.start()
-        await self.mux.start()
+            mux = ChannelMux.from_args(
+                session,
+                loop,
+                self.args,
+                on_local_rx_bytes=self.stats.on_app_rx_bytes,
+                on_local_tx_bytes=self.stats.on_app_tx_bytes
+            )
+            self._sessions.append(session)
+            self._muxes.append(mux)
+            await session.start()
+            await mux.start()
+
+        self._session_obj = self._sessions[0] if self._sessions else None
+        self.stats.bind_session(self._session_obj)
+        if self._muxes:
+            self.mux = RunnerMuxAggregate(self._muxes)
+        else:
+            self.mux = None
 
         
         # 4) Provide references to StatsBoard and start it
@@ -7115,42 +7392,49 @@ class Runner:
 
         self.log.debug("[RUNNER] stop: entering mux.stop")
         try:
-            if self.mux:
-                await self.mux.stop()
+            for mux in reversed(self._muxes):
+                await mux.stop()
         except Exception:
             pass
 
         self.log.debug("[RUNNER] stop: entering _session_obj")
         try:
-            if self._session_obj:
-                await self._session_obj.stop()
+            for session in reversed(self._sessions):
+                await session.stop()
         except Exception:
             pass
         self.log.debug("[RUNNER] stop leaving")
 
 
     # ---- overlay state propagation (unchanged behavior) -----------------------
-    def _on_state_change(self, connected: bool):
-        self.log.debug(f"[SERVER] _on_state_change {connected}")
+    def _on_state_change(self, transport_name: str, session: ISession, connected: bool):
+        self.log.debug(f"[SERVER] _on_state_change transport={transport_name} connected={connected}")
 
         now_mono = time.monotonic()
-        if connected:
+        aggregate_connected = any(s.is_connected() for s in self._sessions) if self._sessions else connected
+        if aggregate_connected:
             self._last_connected_monotonic = now_mono
             self._last_disconnected_monotonic = None
         else:
             if self._last_disconnected_monotonic is None:
                 self._last_disconnected_monotonic = now_mono        
         # Update board
-        self.stats.on_state_change(connected)
+        self.stats.on_state_change(aggregate_connected)
         # Inform mux
-        if self.mux:
+        mux = None
+        try:
+            idx = self._sessions.index(session)
+            mux = self._muxes[idx]
+        except Exception:
+            mux = None
+        if mux:
             try:
-                asyncio.get_running_loop().create_task(self.mux.on_overlay_state(connected))
+                asyncio.get_running_loop().create_task(mux.on_overlay_state(connected))
             except RuntimeError:
                 pass
         # Keep old behavior: reset sender on disconnect
         s = self.stats.session
-        if not connected and s:
+        if not aggregate_connected and s:
             try:
                 s.reset_sender()
             except Exception:
@@ -7237,11 +7521,20 @@ class Runner:
         if not _has('--overlay-transport'):
             p.add_argument(
                 '--overlay-transport',
-                choices=['myudp', 'tcp', 'quic', 'ws'],
                 default='myudp',
                 help="Overlay transport between peers: "
-                     "myudp (current reliable UDP), tcp (single stream), quic (future), ws (future)."
+                     "comma-separated list from myudp,tcp,quic,ws. "
+                     "Multiple transports are supported simultaneously for listening instances."
             )
+        for proto in ("myudp", "tcp", "quic", "ws"):
+            opt = f'--overlay-port-{proto}'
+            if not _has(opt):
+                p.add_argument(
+                    opt,
+                    type=int,
+                    default=None,
+                    help=f'Optional listen port override for overlay transport {proto}. Defaults to --port443 or a deterministic offset when multiple transports are active.'
+                )
         if not _has('--client-restart-if-disconnected'):
             p.add_argument(
                 '--client-restart-if-disconnected',
@@ -7249,21 +7542,55 @@ class Runner:
                 default=0.0,
                 help='If configured as a peer client (--peer set) and overlay stays disconnected for this many seconds, request process restart. 0 disables.'
             )            
-    # ---------- NEW: Runner-scoped factory ----------
     @staticmethod
-    def build_session_from_overlay(args: argparse.Namespace) -> ISession:
+    def _parse_overlay_transports(args: argparse.Namespace) -> List[str]:
+        raw = str(getattr(args, "overlay_transport", "myudp") or "myudp")
+        parts = [p.strip().lower() for p in raw.split(",") if p.strip()]
+        if not parts:
+            parts = ["myudp"]
+        allowed = {"myudp", "tcp", "quic", "ws"}
+        bad = [p for p in parts if p not in allowed]
+        if bad:
+            raise ValueError(f"Unsupported overlay transport(s): {', '.join(sorted(set(bad)))}")
+        seen: List[str] = []
+        for part in parts:
+            if part not in seen:
+                seen.append(part)
+        if len(seen) > 1 and getattr(args, "peer", None):
+            raise ValueError("Multiple --overlay-transport values are currently supported only for listening instances without --peer.")
+        return seen
+
+    @staticmethod
+    def _overlay_port_for(args: argparse.Namespace, transport: str, multi_count: int) -> int:
+        explicit = getattr(args, f"overlay_port_{transport}", None)
+        if explicit:
+            return int(explicit)
+        base = int(getattr(args, "port443", 443))
+        if multi_count <= 1:
+            return base
+        offsets = {"myudp": 0, "tcp": 1, "quic": 2, "ws": 3}
+        return base + offsets[transport]
+
+    @staticmethod
+    def build_sessions_from_overlay(args: argparse.Namespace) -> List[Tuple[str, ISession]]:
         """
-        Return the ISession that implements the chosen overlay transport.
+        Return the ISession(s) that implement the chosen overlay transport(s).
         """
-        choice = getattr(args, "overlay_transport", "myudp")
-        if choice == "tcp":
-            return TcpStreamSession.from_args(args)
-        if choice == "quic":
-            return QuicSession.from_args(args)
-        if choice == "ws":
-            return WebSocketSession.from_args(args)
-        # default: your existing reliable UDP overlay
-        return UdpSession.from_args(args)
+        out: List[Tuple[str, ISession]] = []
+        choices = Runner._parse_overlay_transports(args)
+        for choice in choices:
+            session_args = argparse.Namespace(**vars(args))
+            session_args.overlay_transport = choice
+            session_args.port443 = Runner._overlay_port_for(args, choice, len(choices))
+            if choice == "tcp":
+                out.append((choice, TcpStreamSession.from_args(session_args)))
+            elif choice == "quic":
+                out.append((choice, QuicSession.from_args(session_args)))
+            elif choice == "ws":
+                out.append((choice, WebSocketSession.from_args(session_args)))
+            else:
+                out.append((choice, UdpSession.from_args(session_args)))
+        return out
 
 # ------------ Admin Webinterface ------------
 

--- a/tests/unit/test_channel_mux_listener_mode.py
+++ b/tests/unit/test_channel_mux_listener_mode.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import unittest
+
+from obstacle_bridge.bridge import ChannelMux
+
+
+class _FakeSession:
+    def __init__(self):
+        self.app_cb = None
+
+    def is_connected(self):
+        return False
+
+    def set_on_app_payload(self, cb):
+        self.app_cb = cb
+
+    def send_app(self, payload):
+        return len(payload)
+
+
+class ChannelMuxListenerModeTests(unittest.TestCase):
+    def test_listener_mode_ignores_own_servers(self):
+        args = argparse.Namespace(
+            peer=None,
+            own_servers=['udp,16667,0.0.0.0,udp,127.0.0.1,16666'],
+            mux_tcp_bp_threshold=1,
+            mux_tcp_bp_latency_ms=300,
+            mux_tcp_bp_poll_interval_ms=50,
+        )
+
+        mux = ChannelMux.from_args(_FakeSession(), asyncio.new_event_loop(), args)
+        try:
+            self.assertEqual(mux._services, {})
+        finally:
+            mux.loop.close()
+
+    def test_client_mode_keeps_own_servers(self):
+        args = argparse.Namespace(
+            peer='127.0.0.1',
+            own_servers=['udp,16667,0.0.0.0,udp,127.0.0.1,16666'],
+            mux_tcp_bp_threshold=1,
+            mux_tcp_bp_latency_ms=300,
+            mux_tcp_bp_poll_interval_ms=50,
+        )
+
+        mux = ChannelMux.from_args(_FakeSession(), asyncio.new_event_loop(), args)
+        try:
+            self.assertEqual(len(mux._services), 1)
+            spec = mux._services[1]
+            self.assertEqual(spec.l_proto, 'udp')
+            self.assertEqual(spec.l_port, 16667)
+            self.assertEqual(spec.r_proto, 'udp')
+            self.assertEqual(spec.r_host, '127.0.0.1')
+            self.assertEqual(spec.r_port, 16666)
+        finally:
+            mux.loop.close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_runner_overlay_transports.py
+++ b/tests/unit/test_runner_overlay_transports.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import argparse
+import unittest
+from unittest import mock
+
+from obstacle_bridge.bridge import Runner, TcpStreamSession, UdpSession, QuicSession, WebSocketSession
+
+
+def _args(**overrides):
+    base = dict(
+        overlay_transport='myudp',
+        port443=443,
+        peer=None,
+        overlay_port_myudp=None,
+        overlay_port_tcp=None,
+        overlay_port_quic=None,
+        overlay_port_ws=None,
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+class RunnerOverlayTransportTests(unittest.TestCase):
+    def test_parse_overlay_transports_accepts_comma_separated_values(self):
+        args = _args(overlay_transport='myudp, tcp,quic,ws')
+        self.assertEqual(Runner._parse_overlay_transports(args), ['myudp', 'tcp', 'quic', 'ws'])
+
+    def test_parse_overlay_transports_rejects_multi_transport_clients(self):
+        args = _args(overlay_transport='myudp,ws', peer='127.0.0.1')
+        with self.assertRaises(ValueError):
+            Runner._parse_overlay_transports(args)
+
+    def test_overlay_port_for_uses_deterministic_offsets(self):
+        args = _args(port443=9000)
+        self.assertEqual(Runner._overlay_port_for(args, 'myudp', 4), 9000)
+        self.assertEqual(Runner._overlay_port_for(args, 'tcp', 4), 9001)
+        self.assertEqual(Runner._overlay_port_for(args, 'quic', 4), 9002)
+        self.assertEqual(Runner._overlay_port_for(args, 'ws', 4), 9003)
+
+    def test_build_sessions_from_overlay_uses_per_transport_ports(self):
+        args = _args(overlay_transport='myudp,tcp,quic,ws', port443=7000)
+        seen = []
+
+        def _factory(name):
+            def _inner(ns):
+                seen.append((name, ns.port443))
+                return {'transport': name, 'port': ns.port443}
+            return _inner
+
+        with mock.patch.object(UdpSession, 'from_args', side_effect=_factory('myudp')), \
+             mock.patch.object(TcpStreamSession, 'from_args', side_effect=_factory('tcp')), \
+             mock.patch.object(QuicSession, 'from_args', side_effect=_factory('quic')), \
+             mock.patch.object(WebSocketSession, 'from_args', side_effect=_factory('ws')):
+            sessions = Runner.build_sessions_from_overlay(args)
+
+        self.assertEqual([name for name, _ in sessions], ['myudp', 'tcp', 'quic', 'ws'])
+        self.assertEqual(seen, [('myudp', 7000), ('tcp', 7001), ('quic', 7002), ('ws', 7003)])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_ws_multi_peer.py
+++ b/tests/unit/test_ws_multi_peer.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import unittest
+
+from obstacle_bridge.bridge import WebSocketSession
+
+
+def _server_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        bind443='0.0.0.0',
+        port443=0,
+        peer=None,
+        peer_port=0,
+        ws_path='/',
+        ws_subprotocol=None,
+        ws_tls=False,
+        ws_max_size=65535,
+        ws_payload_mode='binary',
+        ws_static_dir='',
+        ws_send_timeout=3.0,
+        ws_tcp_user_timeout_ms=10000,
+        ws_reconnect_grace=3.0,
+    )
+
+
+class WebSocketMultiPeerMuxRewriteTests(unittest.TestCase):
+    def test_inbound_mux_rewrite_allocates_distinct_server_channels_per_peer(self):
+        session = WebSocketSession(_server_args())
+        payload1 = session._MUX_HDR.pack(7, 0, 1, 0, 4) + b'test'
+        payload2 = session._MUX_HDR.pack(7, 0, 1, 0, 4) + b'test'
+
+        rewritten1 = session._server_rewrite_inbound_app(1, payload1)
+        rewritten2 = session._server_rewrite_inbound_app(2, payload2)
+
+        chan1 = session._MUX_HDR.unpack(rewritten1[:session._MUX_HDR.size])[0]
+        chan2 = session._MUX_HDR.unpack(rewritten2[:session._MUX_HDR.size])[0]
+
+        self.assertNotEqual(chan1, chan2)
+        self.assertEqual(session._server_chan_to_peer[chan1], (1, 7))
+        self.assertEqual(session._server_chan_to_peer[chan2], (2, 7))
+
+    def test_outbound_mux_rewrite_routes_back_to_original_peer_channel(self):
+        session = WebSocketSession(_server_args())
+        inbound = session._MUX_HDR.pack(11, 0, 5, 0, 3) + b'abc'
+        rewritten = session._server_rewrite_inbound_app(9, inbound)
+        mux_chan, proto, counter, mtype, dlen = session._MUX_HDR.unpack(rewritten[:session._MUX_HDR.size])
+
+        routed = session._server_rewrite_outbound_app(rewritten)
+
+        self.assertIsNotNone(routed)
+        peer_id, outbound = routed
+        self.assertEqual(peer_id, 9)
+        self.assertEqual(outbound, inbound)
+        self.assertEqual((proto, counter, mtype, dlen), (0, 5, 0, 3))
+        self.assertIn(mux_chan, session._server_chan_to_peer)
+
+
+class WebSocketMultiPeerSendTests(unittest.IsolatedAsyncioTestCase):
+    async def test_send_app_routes_to_matching_server_peer_queue(self):
+        session = WebSocketSession(_server_args())
+        session._loop = asyncio.get_running_loop()
+        q1 = asyncio.Queue()
+        q2 = asyncio.Queue()
+        session._server_peers = {
+            1: {'peer_id': 1, 'ws': object(), 'tx_queue': q1, 'tx_task': None, 'rx_task': None},
+            2: {'peer_id': 2, 'ws': object(), 'tx_queue': q2, 'tx_task': None, 'rx_task': None},
+        }
+        session._ensure_server_tx_task = lambda ctx: None
+        inbound = session._MUX_HDR.pack(4, 0, 2, 0, 2) + b'hi'
+        rewritten = session._server_rewrite_inbound_app(2, inbound)
+
+        sent = session.send_app(rewritten)
+
+        self.assertEqual(sent, len(rewritten))
+        queued_wire, on_sent = await q2.get()
+        self.assertEqual(queued_wire, bytes([session._K_APP]) + inbound)
+        self.assertTrue(callable(on_sent))
+        self.assertTrue(q1.empty())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Enable listening instances to host multiple overlay transports simultaneously and allow WebSocket overlay servers to accept multiple peers with per-peer mux-channel rewriting. 
- Improve CLI and documentation to describe multi-transport operation and provide a full technical whitepaper for the project. 
- Harden behavior for ChannelMux when running in listener mode where `--own-servers` would be ambiguous.

### Description
- Documentation: expanded `README.md` with repository layout, CLI reference for transports (UDP/TCP/QUIC/WS), admin and logging options, quick-start examples, and included the complete `docs/WHITEPAPER.html` whitepaper. 
- WebSocket server: extended `WebSocketSession` to support multiple server-side peers, added `_MUX_HDR` struct and per-peer mux-channel rewriting, peer management (`_alloc_server_peer_id`, `_alloc_server_mux_chan`, `_server_peers`, `_server_peer_by_ws_id`, `_server_chan_to_peer`, `_server_peer_chan_to_mux`), server send/tx task plumbing (`_ensure_server_tx_task`, `_schedule_server_send`, `_close_server_peer`), and adapted ping/pong / RTT handling so client and server modes behave correctly. 
- ChannelMux: `from_args` now detects listener mode and ignores `--own-servers` when `--peer` is not set to avoid ambiguous local service bindings. CLI help text updated accordingly. 
- Runner: added support for multiple overlay transports via `--overlay-transport` comma-separated list, new factory `build_sessions_from_overlay` (and helpers `_parse_overlay_transports`, `_overlay_port_for`), per-transport port overrides (`--overlay-port-<proto>`), aggregation of multiple `ChannelMux` instances via `RunnerMuxAggregate`, lifecycle changes to create/start/stop multiple sessions and muxes, and aggregated overlay-connected logic. 
- Misc: small logging, state, and API adjustments to integrate the above changes. 

### Testing
- Added unit tests: `tests/unit/test_channel_mux_listener_mode.py`, `tests/unit/test_runner_overlay_transports.py`, and `tests/unit/test_ws_multi_peer.py`. 
- Ran the unit test suite (`python -m unittest discover tests/unit`) and the new tests passed. 
- No automated integration or system tests were reported in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb4d3561c8322ab6256740154e083)