### PR TITLE
Add aioquic and websockets deps; remove two console scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ name = "ObstacleBridge"
 version = "0.1.0"
 description = "Lossy overlay bridge utilities and test tooling"
 requires-python = ">=3.9"
+dependencies = [
+    "aioquic",
+    "websockets",
+]
 
 [tool.setuptools]
 package-dir = {"" = "src"}
@@ -16,5 +20,3 @@ where = ["src"]
 
 [project.scripts]
 ObstacleBridge = "obstacle_bridge.bridge:main"
-ObstacleBridge-overlay-tty = "obstacle_bridge.tools.overlay_tty:main"
-ObstacleBridge-extract-udp-debug = "obstacle_bridge.tools.extract_udp_debug:main"


### PR DESCRIPTION
### Motivation
- Add QUIC/WebSocket runtime dependencies and remove two obsolete console script entries to simplify packaging.

### Description
- Updated `pyproject.toml` to add `dependencies = ["aioquic", "websockets"]` and removed the `ObstacleBridge-overlay-tty` and `ObstacleBridge-extract-udp-debug` entries, leaving only `ObstacleBridge = "obstacle_bridge.bridge:main"`.

### Testing
- Ran an assertion script `python3 - <<'PY' ...` that verified the two console script lines were removed and that the strings `"aioquic"` and `"websockets"` are present, which passed; attempts to parse `pyproject.toml` with `tomllib` and `toml` were attempted but those modules were unavailable in the environment, causing those parses to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c047437ad883229c9acadcccc47844)