### PR TITLE
Fix runner asyncio event loop binding for admin-web startup

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -7257,22 +7257,35 @@ class Runner:
         self.args = args
         self.log = logging.getLogger("runner")
         DebugLoggingConfigurator.debug_logger_status(self.log)
-        self._stop = asyncio.Event()
+        self._stop: Optional[asyncio.Event] = None
+        self._stop_requested = False
         self._session_obj: Optional[ISession] = None
         self.mux: Optional["ChannelMux"] = None
         self._sessions: List[ISession] = []
         self._muxes: List["ChannelMux"] = []
         self.stats = StatsBoard(args )
         self.admin_web = None
-        self._restart_requested = asyncio.Event()
+        self._restart_requested: Optional[asyncio.Event] = None
+        self._restart_requested_flag = False
         self._last_connected_monotonic: Optional[float] = None
         self._last_disconnected_monotonic: Optional[float] = None
         self._client_restart_watchdog_task: Optional[asyncio.Task] = None        
+
+    def _ensure_runtime_events(self) -> None:
+        if self._stop is None:
+            self._stop = asyncio.Event()
+        if self._stop_requested:
+            self._stop.set()
+        if self._restart_requested is None:
+            self._restart_requested = asyncio.Event()
+        if self._restart_requested_flag:
+            self._restart_requested.set()
 
     async def start(self) -> None:
 
         
         self.log.debug("[SERVER] Runner start on session id=%x", id(self))
+        self._ensure_runtime_events()
 
         loop = asyncio.get_running_loop()
         transport_sessions = Runner.build_sessions_from_overlay(self.args)
@@ -7342,6 +7355,8 @@ class Runner:
         await self.start()
         self.log.debug("[SERVER] Run after start")
 
+        assert self._stop is not None
+        assert self._restart_requested is not None
         stop_task = asyncio.create_task(self._stop.wait())
         restart_task = asyncio.create_task(self._restart_requested.wait())
 
@@ -7365,7 +7380,7 @@ class Runner:
             except Exception:
                 self.log.debug("[RUNNER] stop timed out during restart")
 
-        if self._restart_requested.is_set():
+        if self._restart_requested is not None and self._restart_requested.is_set():
             self.log.warning("[RUNNER] exiting rc=75")
             raise SystemExit(75)
 
@@ -7442,7 +7457,9 @@ class Runner:
 
     def request_restart(self) -> None:
         self.log.debug("[SERVER] Runner restart requested")
-        self._restart_requested.set()
+        self._restart_requested_flag = True
+        if self._restart_requested is not None:
+            self._restart_requested.set()
 
     def get_status_snapshot(self) -> dict:
         return self.stats.snapshot_status()
@@ -7454,9 +7471,13 @@ class Runner:
 
     def request_shutdown(self) -> None:
         self.log.debug("[SERVER] Runner shutdown requested")
-        self._stop.set()
+        self._stop_requested = True
+        if self._stop is not None:
+            self._stop.set()
 
     async def _client_restart_watchdog(self) -> None:
+        assert self._stop is not None
+        assert self._restart_requested is not None
         try:
             while not self._stop.is_set():
                 await asyncio.sleep(1.0)

--- a/tests/unit/test_runner_events.py
+++ b/tests/unit/test_runner_events.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import unittest
+
+from obstacle_bridge.bridge import Runner
+
+
+class RunnerEventBindingTests(unittest.IsolatedAsyncioTestCase):
+    def _make_args(self):
+        return argparse.Namespace(
+            no_dashboard=True,
+            bind443='0.0.0.0',
+            port443=443,
+            status=False,
+        )
+
+    async def test_shutdown_event_binds_to_running_loop(self):
+        runner = Runner(self._make_args())
+        runner.request_shutdown()
+
+        runner._ensure_runtime_events()
+
+        self.assertIsNotNone(runner._stop)
+        self.assertTrue(runner._stop.is_set())
+        await asyncio.wait_for(runner._stop.wait(), timeout=0.1)
+
+    async def test_restart_event_binds_to_running_loop(self):
+        runner = Runner(self._make_args())
+        runner.request_restart()
+
+        runner._ensure_runtime_events()
+
+        self.assertIsNotNone(runner._restart_requested)
+        self.assertTrue(runner._restart_requested.is_set())
+        await asyncio.wait_for(runner._restart_requested.wait(), timeout=0.1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash ("Future attached to a different loop") that occurs when `asyncio.Event` objects are created at `Runner` construction time and later awaited on a different running loop (observed during `--admin-web` startup). 
- Preserve shutdown/restart requests issued before the async runtime starts so they take effect once the runtime is available.

### Description
- Lazily create the runner control events by making `self._stop` and `self._restart_requested` optional and initializing them inside a new helper `Runner._ensure_runtime_events()` invoked from `start()` so events are bound to the active loop. 
- Add boolean flags `self._stop_requested` and `self._restart_requested_flag` to record early `request_shutdown()` / `request_restart()` calls and apply them when events are created. 
- Add `assert` checks and `None`-guards where the code awaits or inspects these events (e.g. in `run()` and `_client_restart_watchdog()`), and update `request_shutdown()`/`request_restart()` to set flags and the runtime event if present. 
- Add `tests/unit/test_runner_events.py` with regression tests that request shutdown/restart before the loop exists and then call the new initializer to verify events are created on the running loop.

### Testing
- Ran `python3 -m pytest tests/unit/test_runner_events.py tests/unit/test_channel_mux_listener_mode.py` and all tests passed (`4 passed`).
- Performed a startup smoke-check `timeout 3s python3 -m obstacle_bridge ... --admin-web --no-dashboard` which exercised the runner/admin-web path without reproducing the loop-mismatch error; the environment lacked the `websockets` package so a full WebSocket connection was not exercised.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c059d285f4832292678cd0f7351447)