### PR TITLE
Admin UI: add Peers/Config/Logs tabs, myUDP metrics, and in-memory debug logs with API support

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -154,6 +154,8 @@ async function loadStatus() {
     const rtt = j.transport?.rtt_est_ms;
     const inflight = j.transport?.inflight;
     const errors = j.decode_errors?.unidentified_frames ?? 0;
+    const myudp = j.myudp || {};
+    const retransmit = myudp.retransmit || {};
 
     setText('rttEst', fmtNumber(rtt));
     setText('inflight', fmtInteger(inflight));
@@ -161,9 +163,37 @@ async function loadStatus() {
     setText('sidebarInflight', fmtInteger(inflight));
     setText('decodeErrors', fmtInteger(errors));
     setText('sidebarErrors', fmtInteger(errors));
+    setText('myudpFirstPass', fmtInteger(retransmit.first_pass));
+    setText('myudpRepeatedOnce', fmtInteger(retransmit.repeated_once));
+    setText('myudpRepeatedMultiple', fmtInteger(retransmit.repeated_multiple));
+    setText('myudpConfirmedTotal', fmtInteger(retransmit.confirmed_total));
   } catch (e) {
     console.error('status load failed', e);
   }
+}
+
+function renderPeerTable(rows) {
+  const tbody = document.getElementById('peerConnectionsBody');
+  if (!tbody) return;
+  if (!rows || rows.length === 0) {
+    tbody.innerHTML = '<tr class="empty-row"><td colspan="11">No peer sessions</td></tr>';
+    return;
+  }
+  tbody.innerHTML = rows.map((row) => `
+    <tr>
+      <td class="mono">${fmtInteger(row.id)}</td>
+      <td class="mono">${row.transport || 'n/a'}</td>
+      <td><span class="${(row.connected ? 'role-pill role-server' : 'role-pill role-unknown')}">${row.connected ? 'yes' : 'no'}</span></td>
+      <td class="mono">${row.peer || 'n/a'}</td>
+      <td class="mono">${fmtNumber(row.rtt_est_ms)}</td>
+      <td class="mono">${fmtInteger(row.inflight)}</td>
+      <td class="mono">${fmtInteger(row.open_connections?.udp ?? 0)}</td>
+      <td class="mono">${fmtInteger(row.open_connections?.tcp ?? 0)}</td>
+      <td class="mono">${fmtInteger(row.traffic?.rx_bytes ?? 0)}</td>
+      <td class="mono">${fmtInteger(row.traffic?.tx_bytes ?? 0)}</td>
+      <td class="mono">${fmtInteger(row.decode_errors ?? 0)}</td>
+    </tr>
+  `).join('');
 }
 
 async function loadConnections() {
@@ -174,13 +204,84 @@ async function loadConnections() {
 
     renderConnectionTable('udpConnectionsBody', j.udp || []);
     renderConnectionTable('tcpConnectionsBody', j.tcp || []);
-    document.getElementById('udpOpen').textContent = fmtInteger(j.counts?.udp ?? (j.udp || []).length);
-    document.getElementById('tcpOpen').textContent = fmtInteger(j.counts?.tcp ?? (j.tcp || []).length);
-    const ts = new Date();
-    document.getElementById('connectionsUpdatedAt').textContent =
-      `updated ${ts.toLocaleTimeString()}`;
+    setText('udpOpen', fmtInteger(j.counts?.udp ?? (j.udp || []).length));
+    setText('tcpOpen', fmtInteger(j.counts?.tcp ?? (j.tcp || []).length));
   } catch (e) {
     console.error('connections load failed', e);
+  }
+}
+
+async function loadPeers() {
+  try {
+    const r = await fetch('/api/peers', { cache: 'no-store' });
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    const j = await r.json();
+    renderPeerTable(j.peers || []);
+  } catch (e) {
+    console.error('peers load failed', e);
+  }
+}
+
+async function loadConfig() {
+  try {
+    const r = await fetch('/api/config', { cache: 'no-store' });
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    const j = await r.json();
+    const el = document.getElementById('configJson');
+    if (el) el.textContent = JSON.stringify(j, null, 2);
+  } catch (e) {
+    const el = document.getElementById('configJson');
+    if (el) el.textContent = 'config load failed: ' + e;
+  }
+}
+
+async function saveConfig() {
+  const key = (document.getElementById('configKey')?.value || '').trim();
+  const raw = (document.getElementById('configValue')?.value || '').trim();
+  if (!key) {
+    setText('configMessage', 'Please enter a configuration key.');
+    return;
+  }
+  if (!raw) {
+    setText('configMessage', 'Please enter a value in JSON format.');
+    return;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    setText('configMessage', `Invalid JSON value: ${e}`);
+    return;
+  }
+
+  try {
+    const r = await fetch('/api/config', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ updates: { [key]: parsed } }),
+    });
+    const j = await r.json();
+    if (!r.ok || !j.ok) {
+      throw new Error(j.error || `HTTP ${r.status}`);
+    }
+    setText('configMessage', `Applied ${key}=${JSON.stringify(parsed)}`);
+    await loadConfig();
+  } catch (e) {
+    setText('configMessage', `Apply failed: ${e}`);
+  }
+}
+
+async function loadLogs() {
+  try {
+    const r = await fetch('/api/logs?limit=500', { cache: 'no-store' });
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    const j = await r.json();
+    const lines = Array.isArray(j.lines) ? j.lines : [];
+    const box = document.getElementById('debugLogs');
+    if (box) box.textContent = lines.join('\n');
+  } catch (e) {
+    const box = document.getElementById('debugLogs');
+    if (box) box.textContent = 'debug logs load failed: ' + e;
   }
 }
 
@@ -206,11 +307,20 @@ function initMetaToggle() {
 }
 
 document.getElementById('restartBtn').addEventListener('click', restart);
+document.getElementById('configReloadBtn')?.addEventListener('click', loadConfig);
+document.getElementById('configSaveBtn')?.addEventListener('click', saveConfig);
+document.getElementById('logsReloadBtn')?.addEventListener('click', loadLogs);
 initTabs();
 initMetaToggle();
 loadMeta();
 loadStatus();
 loadConnections();
+loadPeers();
+loadConfig();
+loadLogs();
 setInterval(loadStatus, 1000);
 setInterval(loadConnections, 1000);
+setInterval(loadPeers, 1000);
 setInterval(loadMeta, 5000);
+setInterval(loadConfig, 5000);
+setInterval(loadLogs, 2000);

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -27,6 +27,7 @@
         <nav class="nav-tabs" aria-label="Main navigation">
           <button class="nav-tab active" data-tab="status" type="button">Status</button>
           <button class="nav-tab" data-tab="configuration" type="button">Configuration</button>
+          <button class="nav-tab" data-tab="logs" type="button">Debug Logs</button>
           <button class="nav-tab" data-tab="misc" type="button">Misc</button>
         </nav>
 
@@ -80,6 +81,29 @@
               <div class="metric-label">Inflight</div>
               <div class="metric-value" id="inflight">n/a</div>
               <div class="metric-note">frames currently in flight</div>
+            </article>
+          </section>
+
+          <section class="summary-grid myudp-grid">
+            <article class="metric-card card">
+              <div class="metric-label">myUDP First Pass</div>
+              <div class="metric-value" id="myudpFirstPass">0</div>
+              <div class="metric-note">frames ACKed without resend</div>
+            </article>
+            <article class="metric-card card">
+              <div class="metric-label">myUDP Repeated Once</div>
+              <div class="metric-value" id="myudpRepeatedOnce">0</div>
+              <div class="metric-note">frames resent exactly one time</div>
+            </article>
+            <article class="metric-card card">
+              <div class="metric-label">myUDP Repeated Multiple</div>
+              <div class="metric-value" id="myudpRepeatedMultiple">0</div>
+              <div class="metric-note">frames resent multiple times</div>
+            </article>
+            <article class="metric-card card">
+              <div class="metric-label">myUDP Confirmed Total</div>
+              <div class="metric-value" id="myudpConfirmedTotal">0</div>
+              <div class="metric-note">total app frames confirmed</div>
             </article>
           </section>
 
@@ -154,6 +178,39 @@
           <section class="section-block">
             <div class="section-header">
               <div>
+                <h2>Peer Connections</h2>
+                <p>All active overlay peer sessions and per-peer health metrics</p>
+              </div>
+            </div>
+            <div class="table-card card">
+              <div class="table-wrap">
+                <table class="conn-table">
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Transport</th>
+                      <th>Connected</th>
+                      <th>Peer</th>
+                      <th>RTT Est (ms)</th>
+                      <th>Inflight</th>
+                      <th>UDP Open</th>
+                      <th>TCP Open</th>
+                      <th>RX Bytes</th>
+                      <th>TX Bytes</th>
+                      <th>Decode Errors</th>
+                    </tr>
+                  </thead>
+                  <tbody id="peerConnectionsBody">
+                    <tr class="empty-row"><td colspan="11">No peer sessions</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+
+          <section class="section-block">
+            <div class="section-header">
+              <div>
                 <h2>UDP Connections</h2>
                 <p>Current UDP mappings and client transports</p>
               </div>
@@ -223,9 +280,40 @@
         </section>
 
         <section id="tab-configuration" class="tab-panel">
-          <section class="section-block card empty-state">
-            <h2>Configuration</h2>
-            <p>Grouped configuration editing will land in a later milestone. The page shell is ready so the tab structure already matches the planned router-style layout.</p>
+          <section class="section-block card">
+            <div class="section-header compact">
+              <div>
+                <h2>Configuration</h2>
+                <p>View and modify runtime configuration values exposed by the admin API.</p>
+              </div>
+              <button id="configReloadBtn" class="btn btn-secondary" type="button">Reload</button>
+            </div>
+            <div class="config-form-grid">
+              <label class="config-field">
+                <span>Key</span>
+                <input id="configKey" type="text" placeholder="example: udp_idle_timeout_sec" />
+              </label>
+              <label class="config-field">
+                <span>Value (JSON)</span>
+                <input id="configValue" type="text" placeholder="example: 30 or \"127.0.0.1\"" />
+              </label>
+              <button id="configSaveBtn" class="btn btn-secondary" type="button">Apply</button>
+            </div>
+            <p id="configMessage" class="config-message"></p>
+            <pre id="configJson" class="meta-box"></pre>
+          </section>
+        </section>
+
+        <section id="tab-logs" class="tab-panel">
+          <section class="section-block card">
+            <div class="section-header compact">
+              <div>
+                <h2>Debug Logs</h2>
+                <p>Latest in-memory debug/application logs captured from runtime.</p>
+              </div>
+              <button id="logsReloadBtn" class="btn btn-secondary" type="button">Reload</button>
+            </div>
+            <pre id="debugLogs" class="meta-box"></pre>
           </section>
         </section>
 

--- a/admin_web/style.css
+++ b/admin_web/style.css
@@ -207,6 +207,10 @@ h1 {
   margin-bottom: 22px;
 }
 
+.myudp-grid {
+  margin-top: -8px;
+}
+
 .metric-card {
   padding: 20px;
 }
@@ -355,6 +359,37 @@ h1 {
   border: 1px solid var(--border);
 }
 
+.config-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 12px;
+  margin: 14px 0 10px;
+  align-items: end;
+}
+
+.config-field {
+  display: grid;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.config-field input {
+  width: 100%;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.config-message {
+  min-height: 20px;
+  margin: 0 0 10px;
+  color: #b8d3ff;
+  font-size: 13px;
+}
+
 .meta-box {
   margin-top: 0;
   overflow: auto;
@@ -400,6 +435,10 @@ h1 {
   .summary-grid,
   .traffic-grid,
   .two-col {
+    grid-template-columns: 1fr;
+  }
+
+  .config-form-grid {
     grid-template-columns: 1fr;
   }
 

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -59,6 +59,7 @@ from typing import Dict, Optional, Tuple, List, Set, Deque, Any, Callable
 ANSI_HIDE_CURSOR = "\x1b[?25l"
 ANSI_SHOW_CURSOR = "\x1b[?25h"
 ANSI_HOME_CLEAR = "\x1b[H\x1b[J"
+DEBUG_LOG_RING: Deque[str] = deque(maxlen=1200)
 
 # ============================== Logging / Debug Config ===============================
 def debug_print(msg: str):
@@ -85,6 +86,15 @@ class DebugToStderrHandler(logging.Handler):
             if record.levelno <= logging.DEBUG:
                 msg = self.format(record)
                 debug_print(msg)
+        except Exception:
+            pass
+
+
+class InMemoryDebugLogHandler(logging.Handler):
+    """Capture formatted log lines in a ring buffer for admin web debug tab."""
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            DEBUG_LOG_RING.append(self.format(record))
         except Exception:
             pass
 
@@ -218,6 +228,12 @@ class DebugLoggingConfigurator:
         ch.setLevel(console_level)
         ch.setFormatter(fmt)
         root.addHandler(ch)
+
+        # In-memory ring used by admin web /api/logs.
+        mem = InMemoryDebugLogHandler()
+        mem.setLevel(logging.DEBUG)
+        mem.setFormatter(fmt)
+        root.addHandler(mem)
 
 
         # Optional: route DEBUG to stderr without affecting global level
@@ -7156,6 +7172,9 @@ class StatsBoard:
         def _num(v):
             return None if v is None else v
 
+        hist = dict(getattr(self.session, "stats_hist", {}) or {})
+        repeated_multiple = int(hist.get("thrice", 0)) + int(hist.get("gt3", 0))
+
         return {
             "updated_unix_ts": now_wall,
             "peer_state": self._conn_state,
@@ -7205,6 +7224,17 @@ class StatsBoard:
                 "unidentified_frames": int(
                     getattr(self.peer_proto, "unidentified_frames", 0) if self.peer_proto else 0
                 ),
+            },
+            "myudp": {
+                "retransmit": {
+                    "created_total": int(hist.get("created_total", 0)),
+                    "confirmed_total": int(hist.get("confirmed_total", 0)),
+                    "first_pass": int(hist.get("once", 0)),
+                    "repeated_once": int(hist.get("twice", 0)),
+                    "repeated_multiple": repeated_multiple,
+                    "repeated_three_times": int(hist.get("thrice", 0)),
+                    "repeated_over_three_times": int(hist.get("gt3", 0)),
+                },
             },
         }
         
@@ -7263,6 +7293,7 @@ class Runner:
         self.mux: Optional["ChannelMux"] = None
         self._sessions: List[ISession] = []
         self._muxes: List["ChannelMux"] = []
+        self._session_labels: List[str] = []
         self.stats = StatsBoard(args )
         self.admin_web = None
         self._restart_requested: Optional[asyncio.Event] = None
@@ -7291,6 +7322,7 @@ class Runner:
         transport_sessions = Runner.build_sessions_from_overlay(self.args)
         self._sessions = []
         self._muxes = []
+        self._session_labels = []
         for transport_name, session in transport_sessions:
             session.set_on_state_change(lambda connected, transport_name=transport_name, session=session: self._on_state_change(transport_name, session, connected))
             session.set_on_peer_rx(self.stats.on_peer_rx_bytes)
@@ -7307,6 +7339,7 @@ class Runner:
             )
             self._sessions.append(session)
             self._muxes.append(mux)
+            self._session_labels.append(transport_name)
             await session.start()
             await mux.start()
 
@@ -7468,6 +7501,104 @@ class Runner:
         if self.mux is None:
             return {"udp": [], "tcp": [], "counts": {"udp": 0, "tcp": 0}}
         return self.mux.snapshot_connections()
+
+    def get_config_snapshot(self) -> dict:
+        blocked = {
+            "config", "dump_config", "save_config", "save_format", "force",
+            "help",
+        }
+        data = {}
+        for k, v in vars(self.args).items():
+            if k.startswith("_") or k in blocked:
+                continue
+            if isinstance(v, (str, int, float, bool, list, dict)) or v is None:
+                data[k] = v
+            else:
+                data[k] = str(v)
+        return data
+
+    def get_debug_logs(self, limit: int = 400) -> list:
+        lim = max(1, min(int(limit), 1000))
+        if not DEBUG_LOG_RING:
+            return []
+        return list(DEBUG_LOG_RING)[-lim:]
+
+    def get_peer_connections_snapshot(self) -> dict:
+        peers: list = []
+        for idx, session in enumerate(self._sessions):
+            mux = self._muxes[idx] if idx < len(self._muxes) else None
+            label = self._session_labels[idx] if idx < len(self._session_labels) else f"session-{idx}"
+            m = session.get_metrics()
+            udp_rows: list = []
+            tcp_rows: list = []
+            if mux is not None:
+                snap = mux.snapshot_connections()
+                udp_rows = list(snap.get("udp", []))
+                tcp_rows = list(snap.get("tcp", []))
+            rx_bytes = 0
+            tx_bytes = 0
+            for row in udp_rows + tcp_rows:
+                st = row.get("stats", {})
+                rx_bytes += int(st.get("rx_bytes", 0) or 0)
+                tx_bytes += int(st.get("tx_bytes", 0) or 0)
+            peer_label = None
+            with contextlib.suppress(Exception):
+                if hasattr(session, "peer_proto") and getattr(session, "peer_proto"):
+                    pa = getattr(getattr(session, "peer_proto"), "send_port").peer_addr
+                    if pa:
+                        peer_label = f"{pa[0]}:{pa[1]}"
+            decode_errors = 0
+            with contextlib.suppress(Exception):
+                pp = getattr(session, "peer_proto", None)
+                if pp is not None:
+                    decode_errors = int(getattr(pp, "unidentified_frames", 0) or 0)
+            peers.append({
+                "id": idx,
+                "transport": label,
+                "connected": bool(session.is_connected()),
+                "peer": peer_label,
+                "rtt_est_ms": m.rtt_est_ms,
+                "inflight": m.inflight,
+                "decode_errors": decode_errors,
+                "open_connections": {
+                    "udp": len(udp_rows),
+                    "tcp": len(tcp_rows),
+                },
+                "traffic": {
+                    "rx_bytes": rx_bytes,
+                    "tx_bytes": tx_bytes,
+                },
+            })
+        return {"peers": peers, "count": len(peers)}
+
+    def update_config(self, updates: dict) -> tuple[bool, str]:
+        if not isinstance(updates, dict):
+            return (False, "updates must be an object")
+        for key, value in updates.items():
+            if not hasattr(self.args, key):
+                return (False, f"unknown config key: {key}")
+            cur = getattr(self.args, key)
+            if isinstance(cur, bool):
+                if not isinstance(value, bool):
+                    return (False, f"{key} expects boolean")
+            elif isinstance(cur, int) and not isinstance(cur, bool):
+                if not isinstance(value, int):
+                    return (False, f"{key} expects integer")
+            elif isinstance(cur, float):
+                if not isinstance(value, (int, float)):
+                    return (False, f"{key} expects number")
+                value = float(value)
+            elif isinstance(cur, str):
+                if not isinstance(value, str):
+                    return (False, f"{key} expects string")
+            elif isinstance(cur, list):
+                if not isinstance(value, list):
+                    return (False, f"{key} expects list")
+            elif cur is None:
+                if not isinstance(value, (str, int, float, bool, list, dict)) and value is not None:
+                    return (False, f"{key} has unsupported type")
+            setattr(self.args, key, value)
+        return (True, "")
 
     def request_shutdown(self) -> None:
         self.log.debug("[SERVER] Runner shutdown requested")
@@ -7704,6 +7835,7 @@ class AdminWebUI:
             method, raw_path, _httpver = parts
             headers = {}
 
+            content_length = 0
             while True:
                 line = await reader.readline()
                 if not line or line in (b"\r\n", b"\n"):
@@ -7711,7 +7843,16 @@ class AdminWebUI:
                 text = line.decode("utf-8", "replace")
                 if ":" in text:
                     k, v = text.split(":", 1)
-                    headers[k.strip().lower()] = v.strip()
+                    hk = k.strip().lower()
+                    hv = v.strip()
+                    headers[hk] = hv
+                    if hk == "content-length":
+                        with contextlib.suppress(Exception):
+                            content_length = max(0, int(hv))
+
+            body = b""
+            if content_length > 0:
+                body = await reader.readexactly(content_length)
 
             path = raw_path.split("?", 1)[0]
             self.log.info("ADMIN REQUEST method=%s path=%s", method, path)
@@ -7742,6 +7883,18 @@ class AdminWebUI:
                 await self._handle_connections(writer)
                 return
 
+            if path == "/api/config":
+                await self._handle_config(writer, method, body)
+                return
+
+            if path == "/api/logs":
+                await self._handle_logs(writer, raw_path)
+                return
+
+            if path == "/api/peers":
+                await self._handle_peers(writer)
+                return
+
             await self._handle_static(writer, path)
 
         except Exception:            
@@ -7770,6 +7923,57 @@ class AdminWebUI:
             "milestone": "C",
         }
         self._log_api_response("/api/meta", 200, payload)
+        await self._send_json(writer, 200, payload)
+
+    async def _handle_config(self, writer, method: str, body: bytes):
+        if method == "GET":
+            payload = {
+                "ok": True,
+                "config": self.runner.get_config_snapshot(),
+            }
+            self._log_api_response("/api/config", 200, payload, summary="config snapshot")
+            await self._send_json(writer, 200, payload)
+            return
+
+        if method != "POST":
+            await self._send(writer, 405, b"Method Not Allowed", "text/plain; charset=utf-8")
+            return
+
+        try:
+            req = json.loads((body or b"{}").decode("utf-8"))
+        except Exception:
+            await self._send_json(writer, 400, {"ok": False, "error": "invalid JSON body"})
+            return
+        updates = req.get("updates", {})
+        ok, err = self.runner.update_config(updates)
+        if not ok:
+            await self._send_json(writer, 400, {"ok": False, "error": err})
+            return
+        payload = {"ok": True, "config": self.runner.get_config_snapshot()}
+        self._log_api_response("/api/config", 200, payload, summary=f"updated keys={list(updates.keys())}")
+        await self._send_json(writer, 200, payload)
+
+    async def _handle_logs(self, writer, raw_path: str):
+        limit = 400
+        with contextlib.suppress(Exception):
+            if "?" in raw_path:
+                query = raw_path.split("?", 1)[1]
+                for pair in query.split("&"):
+                    if not pair:
+                        continue
+                    k, _, v = pair.partition("=")
+                    if k == "limit":
+                        limit = int(v)
+                        break
+        lines = self.runner.get_debug_logs(limit=limit)
+        payload = {"ok": True, "lines": lines, "count": len(lines)}
+        self._log_api_response("/api/logs", 200, payload, summary=f"count={len(lines)}")
+        await self._send_json(writer, 200, payload)
+
+    async def _handle_peers(self, writer):
+        payload = self.runner.get_peer_connections_snapshot()
+        payload["ok"] = True
+        self._log_api_response("/api/peers", 200, payload, summary=f"count={payload.get('count', 0)}")
         await self._send_json(writer, 200, payload)
 
     async def _handle_restart(self, writer, method, headers):


### PR DESCRIPTION
### Motivation

- Expand the admin web UI to surface per-peer state, runtime configuration editing, and recent debug logs for easier troubleshooting and runtime tuning.
- Expose additional runtime metrics (myUDP retransmit histogram) in the status snapshot so the UI can show retransmit breakdowns.
- Capture recent DEBUG-level log lines in an in-memory ring buffer so the web UI can present recent logs without requiring a log file.

### Description

- Add an in-memory ring buffer `DEBUG_LOG_RING` and `InMemoryDebugLogHandler` and wire it into the logging configurator so DEBUG-level lines are captured for the admin API.
- Extend `StatsBoard.snapshot_status()` to include a `myudp.retransmit` block with retransmit histogram counters and compute `repeated_multiple` from histogram buckets.
- Add Runner APIs: `get_config_snapshot()`, `get_debug_logs(limit)`, `get_peer_connections_snapshot()` and `update_config(updates)` to expose config values, recent logs, per-session peer snapshots, and allow controlled runtime config updates.
- Augment AdminWebUI request handling to read request body via `Content-Length` and add HTTP handlers for `/api/config` (GET/POST), `/api/logs` (GET with `limit`), and `/api/peers` (GET), and include server-side validation for config updates.
- Add client-side UI changes in `admin_web/app.js` and `admin_web/index.html` to render peer sessions, a new myUDP metrics grid, configuration editor (reload/apply), and debug logs tab, plus corresponding polling (`loadPeers`, `loadConfig`, `loadLogs`) and DOM updates; update `style.css` with layout and form styles.
- Misc: minor request header parsing robustness, session transport labeling, tracking session labels in Runner, and several tidy-ups to existing connection/status rendering logic.

### Testing

- No automated tests were added or executed as part of this change (no CI test runs included with this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a7ea1308832297e605822e9475a2)