### PR TITLE
Admin web UI cleanup and sectioned configuration editor

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -128,8 +128,6 @@ async function loadStatus() {
     const j = await r.json();
 
     applyPeerState(j.peer_state);
-    setText('overlayBind', j.overlay?.bind ?? 'n/a');
-    setText('overlayPeer', j.overlay?.peer ?? 'n/a');
     setText('detailOverlayBind', j.overlay?.bind ?? 'n/a');
     setText('detailOverlayPeer', j.overlay?.peer ?? 'n/a');
 
@@ -159,10 +157,7 @@ async function loadStatus() {
 
     setText('rttEst', fmtNumber(rtt));
     setText('inflight', fmtInteger(inflight));
-    setText('sidebarRtt', rtt == null ? 'n/a' : `${fmtNumber(rtt)} ms`);
-    setText('sidebarInflight', fmtInteger(inflight));
     setText('decodeErrors', fmtInteger(errors));
-    setText('sidebarErrors', fmtInteger(errors));
     setText('myudpFirstPass', fmtInteger(retransmit.first_pass));
     setText('myudpRepeatedOnce', fmtInteger(retransmit.repeated_once));
     setText('myudpRepeatedMultiple', fmtInteger(retransmit.repeated_multiple));
@@ -227,30 +222,38 @@ async function loadConfig() {
     const r = await fetch('/api/config', { cache: 'no-store' });
     if (!r.ok) throw new Error('HTTP ' + r.status);
     const j = await r.json();
-    const el = document.getElementById('configJson');
-    if (el) el.textContent = JSON.stringify(j, null, 2);
+    configState = {
+      config: j.config || {},
+      schema: j.schema || {},
+    };
+    renderConfigSections(configState.schema, configState.config);
+    setText('configMessage', '');
   } catch (e) {
-    const el = document.getElementById('configJson');
-    if (el) el.textContent = 'config load failed: ' + e;
+    setText('configMessage', 'config load failed: ' + e);
   }
 }
 
 async function saveConfig() {
-  const key = (document.getElementById('configKey')?.value || '').trim();
-  const raw = (document.getElementById('configValue')?.value || '').trim();
-  if (!key) {
-    setText('configMessage', 'Please enter a configuration key.');
-    return;
+  const editors = Array.from(document.querySelectorAll('.config-editor[data-config-key]'));
+  if (editors.length === 0) return;
+
+  const updates = {};
+  for (const input of editors) {
+    const key = input.getAttribute('data-config-key');
+    const raw = (input.value || '').trim();
+    try {
+      const parsed = JSON.parse(raw);
+      const current = configState.config ? configState.config[key] : undefined;
+      if (JSON.stringify(parsed) !== JSON.stringify(current)) {
+        updates[key] = parsed;
+      }
+    } catch (e) {
+      setText('configMessage', `Invalid JSON for ${key}: ${e}`);
+      return;
+    }
   }
-  if (!raw) {
-    setText('configMessage', 'Please enter a value in JSON format.');
-    return;
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (e) {
-    setText('configMessage', `Invalid JSON value: ${e}`);
+  if (Object.keys(updates).length === 0) {
+    setText('configMessage', 'No configuration changes to save.');
     return;
   }
 
@@ -258,17 +261,76 @@ async function saveConfig() {
     const r = await fetch('/api/config', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ updates: { [key]: parsed } }),
+      body: JSON.stringify({ updates }),
     });
     const j = await r.json();
     if (!r.ok || !j.ok) {
       throw new Error(j.error || `HTTP ${r.status}`);
     }
-    setText('configMessage', `Applied ${key}=${JSON.stringify(parsed)}`);
+    setText('configMessage', `Saved ${Object.keys(updates).length} configuration value(s).`);
     await loadConfig();
   } catch (e) {
-    setText('configMessage', `Apply failed: ${e}`);
+    setText('configMessage', `Save failed: ${e}`);
   }
+}
+
+let configState = {
+  config: {},
+  schema: {},
+};
+
+function configValueToEditor(value) {
+  return JSON.stringify(value);
+}
+
+function renderConfigSections(schema, config) {
+  const root = document.getElementById('configSections');
+  if (!root) return;
+  const sectionNames = Object.keys(schema || {});
+  if (sectionNames.length === 0) {
+    root.innerHTML = '<div class="empty-state card"><p>No configuration schema available.</p></div>';
+    return;
+  }
+
+  root.innerHTML = sectionNames.map((section) => {
+    const items = schema[section] || [];
+    const rows = items.map((item) => {
+      const key = item.key;
+      const current = Object.prototype.hasOwnProperty.call(config, key) ? config[key] : null;
+      const currentRaw = configValueToEditor(current);
+      const defaultRaw = configValueToEditor(item.default);
+      return `
+        <tr>
+          <td class="mono">${key}</td>
+          <td>${item.description || '(no description)'}</td>
+          <td class="mono">${defaultRaw}</td>
+          <td><input class="config-editor mono" data-config-key="${key}" value="${currentRaw.replace(/"/g, '&quot;')}" /></td>
+        </tr>
+      `;
+    }).join('');
+    return `
+      <section class="config-section card">
+        <div class="section-header compact">
+          <div>
+            <h3>${section}</h3>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table class="conn-table">
+            <thead>
+              <tr>
+                <th>Key</th>
+                <th>Description</th>
+                <th>Default</th>
+                <th>Current (JSON)</th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      </section>
+    `;
+  }).join('');
 }
 
 async function loadLogs() {

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Router Admin</title>
+  <title>ObstacleBridge</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -11,7 +11,7 @@
     <header class="topbar">
       <div>
         <div class="eyebrow">Network Appliance</div>
-        <h1>Router Admin</h1>
+        <h1>ObstacleBridge</h1>
       </div>
       <div class="topbar-right">
         <div class="status-cluster">
@@ -32,29 +32,9 @@
         </nav>
 
         <section class="sidebar-section">
-          <div class="sidebar-title">Overlay</div>
+          <div class="sidebar-title">Runtime</div>
           <div class="kv-list">
-            <div class="kv-row"><span>Bind</span><strong id="overlayBind">n/a</strong></div>
-            <div class="kv-row"><span>Peer</span><strong id="overlayPeer">n/a</strong></div>
             <div class="kv-row"><span>Uptime</span><strong id="uptimeSec">n/a</strong></div>
-          </div>
-        </section>
-
-        <section class="sidebar-section">
-          <div class="sidebar-title">Quick Health</div>
-          <div class="health-stack">
-            <div class="health-item">
-              <span class="health-label">RTT Estimate</span>
-              <strong id="sidebarRtt">n/a</strong>
-            </div>
-            <div class="health-item">
-              <span class="health-label">Inflight</span>
-              <strong id="sidebarInflight">n/a</strong>
-            </div>
-            <div class="health-item">
-              <span class="health-label">Decode Errors</span>
-              <strong id="sidebarErrors">0</strong>
-            </div>
           </div>
         </section>
       </aside>
@@ -158,19 +138,6 @@
                 <div class="detail-row"><span>Peer State</span><strong id="peerState">n/a</strong></div>
                 <div class="detail-row"><span>Overlay Bind</span><strong id="detailOverlayBind">n/a</strong></div>
                 <div class="detail-row"><span>Overlay Peer</span><strong id="detailOverlayPeer">n/a</strong></div>
-              </div>
-            </section>
-
-            <section class="section-block card warning-card">
-              <div class="section-header compact">
-                <div>
-                  <h2>Errors</h2>
-                  <p>Decoder and protocol error counters</p>
-                </div>
-              </div>
-              <div class="error-main">
-                <span class="error-label">Decode Errors</span>
-                <span id="decodeErrors" class="error-value">0</span>
               </div>
             </section>
           </div>
@@ -284,23 +251,15 @@
             <div class="section-header compact">
               <div>
                 <h2>Configuration</h2>
-                <p>View and modify runtime configuration values exposed by the admin API.</p>
+                <p>Configuration is organized by section (for example: admin_web and ws_session), with description and built-in default value.</p>
               </div>
-              <button id="configReloadBtn" class="btn btn-secondary" type="button">Reload</button>
-            </div>
-            <div class="config-form-grid">
-              <label class="config-field">
-                <span>Key</span>
-                <input id="configKey" type="text" placeholder="example: udp_idle_timeout_sec" />
-              </label>
-              <label class="config-field">
-                <span>Value (JSON)</span>
-                <input id="configValue" type="text" placeholder="example: 30 or \"127.0.0.1\"" />
-              </label>
-              <button id="configSaveBtn" class="btn btn-secondary" type="button">Apply</button>
+              <div class="config-actions">
+                <button id="configReloadBtn" class="btn btn-secondary" type="button">Reload</button>
+                <button id="configSaveBtn" class="btn btn-secondary" type="button">Save Configuration</button>
+              </div>
             </div>
             <p id="configMessage" class="config-message"></p>
-            <pre id="configJson" class="meta-box"></pre>
+            <div id="configSections" class="config-sections"></div>
           </section>
         </section>
 

--- a/admin_web/style.css
+++ b/admin_web/style.css
@@ -359,28 +359,27 @@ h1 {
   border: 1px solid var(--border);
 }
 
-.config-form-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr auto;
-  gap: 12px;
-  margin: 14px 0 10px;
-  align-items: end;
+.config-actions {
+  display: flex;
+  gap: 10px;
 }
 
-.config-field {
+.config-sections {
   display: grid;
-  gap: 6px;
-  font-size: 13px;
-  color: var(--muted);
+  gap: 14px;
 }
 
-.config-field input {
+.config-section {
+  padding: 14px;
+}
+
+.config-editor {
   width: 100%;
   border: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.04);
   color: var(--text);
   border-radius: 10px;
-  padding: 10px 12px;
+  padding: 8px 10px;
 }
 
 .config-message {
@@ -435,10 +434,6 @@ h1 {
   .summary-grid,
   .traffic-grid,
   .two-col {
-    grid-template-columns: 1fr;
-  }
-
-  .config-form-grid {
     grid-template-columns: 1fr;
   }
 

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -7517,6 +7517,26 @@ class Runner:
                 data[k] = str(v)
         return data
 
+    def get_config_schema_snapshot(self) -> dict:
+        sections = getattr(self.args, "_config_sections", {}) or {}
+        defaults = getattr(self.args, "_config_defaults", {}) or {}
+        descriptions = getattr(self.args, "_config_help", {}) or {}
+
+        schema: dict = {}
+        for section in sorted(sections.keys()):
+            items = []
+            for key in sorted(sections.get(section, [])):
+                if not hasattr(self.args, key):
+                    continue
+                items.append({
+                    "key": key,
+                    "description": descriptions.get(key, "(no description)"),
+                    "default": defaults.get(key, None),
+                })
+            if items:
+                schema[section] = items
+        return schema
+
     def get_debug_logs(self, limit: int = 400) -> list:
         lim = max(1, min(int(limit), 1000))
         if not DEBUG_LOG_RING:
@@ -7930,6 +7950,7 @@ class AdminWebUI:
             payload = {
                 "ok": True,
                 "config": self.runner.get_config_snapshot(),
+                "schema": self.runner.get_config_schema_snapshot(),
             }
             self._log_api_response("/api/config", 200, payload, summary="config snapshot")
             await self._send_json(writer, 200, payload)
@@ -8552,6 +8573,9 @@ def main(argv: Optional[List[str]] = None) -> None:
         ("runner",             Runner.register_overlay_cli),
     ]
     args = cli.parse_args(argv, registrars)
+    args._config_sections = {k: sorted(v) for k, v in cli.sections.items()}
+    args._config_defaults = dict(cli._baseline_defaults)
+    args._config_help = dict(cli._action_help)
 
     # Apply logging in one line (behavior unchanged)
     DebugLoggingConfigurator.from_args(args).apply()


### PR DESCRIPTION
### Motivation
- Simplify and rebrand the admin UI by removing the left sidebar overlay/quick-health summary and the Errors card, and rename the page to ObstacleBridge. 
- Replace the single key/value runtime config editor with a sectioned, documented editor that shows per-section keys, descriptions and built-in defaults, and supports a single bulk-save action. 

### Description
- Updated admin HTML to change title/header to `ObstacleBridge` and removed the left sidebar "Overlay" and "Quick Health" blocks and the status "Errors" card in `admin_web/index.html`. 
- Implemented a sectioned, editable configuration renderer and bulk save flow in `admin_web/app.js` that consumes a `schema` from the API and posts changed keys as `{ updates: {...} }`. 
- Added CSS for configuration sections, editors and actions in `admin_web/style.css`, and removed the old single-key/value form. 
- Extended backend admin API in `src/obstacle_bridge/bridge.py` to expose `schema` via `/api/config` by adding `get_config_schema_snapshot()` and wiring argparse-derived metadata into runtime args (`_config_sections`, `_config_defaults`, `_config_help`). 

### Testing
- Ran Python compile check with `python -m py_compile src/obstacle_bridge/bridge.py`, which succeeded. 
- Verified the admin JS parses with Node using `node -e "new Function(require('fs').readFileSync('admin_web/app.js','utf8')); console.log('OK_js')"`, which succeeded. 
- Project changes were committed successfully as part of the update workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c347e87ae48322838ec3d8758037f4)