### PR TITLE
Display human-readable peer traffic and simplify two-column layout

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -197,8 +197,8 @@ function renderPeerTable(rows) {
       <td class="mono">${fmtInteger(row.inflight)}</td>
       <td class="mono">${fmtInteger(row.open_connections?.udp ?? 0)}</td>
       <td class="mono">${fmtInteger(row.open_connections?.tcp ?? 0)}</td>
-      <td class="mono">${fmtInteger(row.traffic?.rx_bytes ?? 0)}</td>
-      <td class="mono">${fmtInteger(row.traffic?.tx_bytes ?? 0)}</td>
+      <td class="mono">${fmtBytes(row.traffic?.rx_bytes ?? 0)}</td>
+      <td class="mono">${fmtBytes(row.traffic?.tx_bytes ?? 0)}</td>
       <td class="mono">${fmtInteger(row.decode_errors ?? 0)}</td>
     </tr>
   `).join('');

--- a/admin_web/style.css
+++ b/admin_web/style.css
@@ -308,7 +308,7 @@ h1 {
 
 .two-col {
   display: grid;
-  grid-template-columns: 1.6fr 1fr;
+  grid-template-columns: 1fr;
   gap: 18px;
 }
 


### PR DESCRIPTION
### Motivation
- Make peer traffic columns show human-readable byte units instead of raw integers for better operator readability.
- Simplify the `.two-col` layout to a single-column grid to improve layout consistency/responsiveness.

### Description
- Replaced `fmtInteger(row.traffic?.rx_bytes ?? 0)` and `fmtInteger(row.traffic?.tx_bytes ?? 0)` with `fmtBytes(...)` in `admin_web/app.js` to render RX/TX as formatted byte strings in the peer table.
- Updated `.two-col` in `admin_web/style.css` to use `grid-template-columns: 1fr` (single column) and preserved the gap to simplify the layout.

### Testing
- Ran `npm run lint` against the `admin_web` codebase and the linter reported no errors.
- Ran `npm test` for frontend unit tests and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c35051209083229ebe068d92170f50)