### PR TITLE
Enable admin web by default, improve admin UI config rendering, tighten config-file handling, add run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The tables below are generated from the current parser registrations in `bridge.
 ### Admin web
 | Option(s) | Default | Description |
 |---|---:|---|
-| `--admin-web` | `False` | Enable admin web interface |
+| `--admin-web` | `True` | Enable admin web interface |
 | `--admin-web-bind` | `127.0.0.1` | Bind address for admin web interface |
 | `--admin-web-port` | `18080` | Port for admin web interface |
 | `--admin-web-path` | `/` | Base path for admin web interface |

--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -296,6 +296,48 @@ function configValueToEditor(value) {
   return JSON.stringify(value);
 }
 
+function renderConfigRows(items, config) {
+  return (items || []).map((item) => {
+    const key = item.key;
+    const current = Object.prototype.hasOwnProperty.call(config, key) ? config[key] : null;
+    const currentRaw = configValueToEditor(current);
+    const defaultRaw = configValueToEditor(item.default);
+    return `
+      <tr>
+        <td class="mono">${key}</td>
+        <td>${item.description || '(no description)'}</td>
+        <td class="mono">${defaultRaw}</td>
+        <td><input class="config-editor mono" data-config-key="${key}" value="${currentRaw.replace(/"/g, '&quot;')}" /></td>
+      </tr>
+    `;
+  }).join('');
+}
+
+function renderConfigCard(title, rowsHtml) {
+  return `
+    <section class="config-section card">
+      <div class="section-header compact">
+        <div>
+          <h3>${title}</h3>
+        </div>
+      </div>
+      <div class="table-wrap">
+        <table class="conn-table">
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Description</th>
+              <th>Default</th>
+              <th>Current (JSON)</th>
+            </tr>
+          </thead>
+          <tbody>${rowsHtml}</tbody>
+        </table>
+      </div>
+    </section>
+  `;
+}
+
 function renderConfigSections(schema, config) {
   const root = document.getElementById('configSections');
   if (!root) return;
@@ -305,45 +347,27 @@ function renderConfigSections(schema, config) {
     return;
   }
 
-  root.innerHTML = sectionNames.map((section) => {
+  const debugLogItems = [];
+  const cards = [];
+
+  sectionNames.forEach((section) => {
     const items = schema[section] || [];
-    const rows = items.map((item) => {
-      const key = item.key;
-      const current = Object.prototype.hasOwnProperty.call(config, key) ? config[key] : null;
-      const currentRaw = configValueToEditor(current);
-      const defaultRaw = configValueToEditor(item.default);
-      return `
-        <tr>
-          <td class="mono">${key}</td>
-          <td>${item.description || '(no description)'}</td>
-          <td class="mono">${defaultRaw}</td>
-          <td><input class="config-editor mono" data-config-key="${key}" value="${currentRaw.replace(/"/g, '&quot;')}" /></td>
-        </tr>
-      `;
-    }).join('');
-    return `
-      <section class="config-section card">
-        <div class="section-header compact">
-          <div>
-            <h3>${section}</h3>
-          </div>
-        </div>
-        <div class="table-wrap">
-          <table class="conn-table">
-            <thead>
-              <tr>
-                <th>Key</th>
-                <th>Description</th>
-                <th>Default</th>
-                <th>Current (JSON)</th>
-              </tr>
-            </thead>
-            <tbody>${rows}</tbody>
-          </table>
-        </div>
-      </section>
-    `;
-  }).join('');
+    const sectionDebugItems = items.filter((item) => String(item.key || '').startsWith('log_'));
+    const sectionRegularItems = items.filter((item) => !String(item.key || '').startsWith('log_'));
+
+    if (sectionDebugItems.length > 0) {
+      debugLogItems.push(...sectionDebugItems);
+    }
+    if (sectionRegularItems.length > 0) {
+      cards.push(renderConfigCard(section, renderConfigRows(sectionRegularItems, config)));
+    }
+  });
+
+  if (debugLogItems.length > 0) {
+    cards.unshift(renderConfigCard('Debug logging (per class/section)', renderConfigRows(debugLogItems, config)));
+  }
+
+  root.innerHTML = cards.join('');
 }
 
 async function loadLogs() {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Den gewünschten Befehl hier definieren
+COMMAND="./bin/python3 -m obstacle_bridge -c obstacle_bridge.cfg"
+
+until [ $? -eq 75 ]; do
+  $COMMAND > /dev/null
+done

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -7773,6 +7773,7 @@ class AdminWebUI:
         g.add_argument(
             "--admin-web",
             action="store_true",
+            default=True,
             help="Enable admin web interface",
         )
         g.add_argument(
@@ -8161,15 +8162,19 @@ class ConfigAwareCLI:
     ) -> argparse.Namespace:
         # Phase 0: bootstrap to get config & dump/save wants
         boot_args, remaining = self._parse_bootstrap(argv)
+        argv_list = list(argv) if argv is not None else sys.argv[1:]
+        explicit_config_flag = any(a in ("-c", "--config") for a in argv_list)
 
         # Phase 1: build full parser and register CLI from single source of truth
         parser = self._build_full_parser(registrars)
 
         # Phase 2: apply JSON config as defaults (if provided)
         if boot_args.config:
-            cfg = self._load_json_config(boot_args.config)
-            self._raw_config = cfg
-            self._apply_config_defaults_from_json(parser, cfg)
+            config_path = pathlib.Path(boot_args.config)
+            if explicit_config_flag or config_path.exists():
+                cfg = self._load_json_config(boot_args.config)
+                self._raw_config = cfg
+                self._apply_config_defaults_from_json(parser, cfg)
 
         # Phase 3: final parse; CLI overrides config/defaults
         args = parser.parse_args(remaining)
@@ -8204,7 +8209,7 @@ class ConfigAwareCLI:
     # ---------- internal: bootstrap / build ----------
     def _parse_bootstrap(self, argv: Optional[List[str]]):
         p = argparse.ArgumentParser(add_help=False)
-        p.add_argument("--config", "-c", default=None,
+        p.add_argument("--config", "-c", default="ObstacleBridge.cfg",
                        help="Path to a JSON config file. Values become defaults that CLI can override.")
         # Optional argument: if omitted -> const="human"
         p.add_argument("--dump-config", nargs="?", const="human",


### PR DESCRIPTION
### Motivation

- Enable the admin web interface by default and make the admin UI easier to use for editing configuration values.  
- Group per-class/section debug logging keys together in the admin UI for easier inspection and editing.  
- Make CLI JSON config loading more robust by providing a sane default config path and only loading JSON when the user explicitly requested it or the file exists.  
- Add a simple launcher script to repeatedly start the service in a loop for local runs.

### Description

- Update documentation default for `--admin-web` in `README.md` to `True`.  
- Change `AdminWebUI.register_cli` to set `--admin-web` default to `True` in `src/obstacle_bridge/bridge.py`.  
- Improve config editor UI in `admin_web/app.js` by adding `renderConfigRows` and `renderConfigCard`, refactoring `renderConfigSections` to render normal sections and to group `log_*` keys under a `Debug logging (per class/section)` card, and ensure JSON current/default values are rendered safely.  
- Harden `ConfigAwareCLI.parse_args` in `src/obstacle_bridge/bridge.py` by defaulting the bootstrap `--config` to `ObstacleBridge.cfg`, capturing `argv` into `argv_list`, and only loading the JSON config when `-c/--config` was explicitly provided or when the config file actually exists.  
- Add a simple launcher script `scripts/run.sh` that repeatedly runs the bridge command until an exit status of `75` is observed.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3541299648322a4986fc4af4b9bba)