### PR TITLE
Handle null values when loading JSON config defaults

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -8509,6 +8509,8 @@ class ConfigAwareCLI:
 
         def apply_type(x: Any) -> Any:
             t = getattr(action, "type", None)
+            if x is None:
+                return None
             return x if t is None else t(x)
 
         # nargs / append list semantics
@@ -8524,6 +8526,8 @@ class ConfigAwareCLI:
             coerced = [apply_type(v) for v in items]
             if choices is not None:
                 for v in coerced:
+                    if v is None:
+                        continue
                     if v not in choices:
                         raise ValueError(f"Invalid value {v!r}; expected one of {sorted(choices)}")
             return coerced
@@ -8534,7 +8538,7 @@ class ConfigAwareCLI:
 
         # scalar
         v = apply_type(val)
-        if choices is not None and v not in choices:
+        if choices is not None and v is not None and v not in choices:
             raise ValueError(f"Invalid value {v!r}; expected one of {sorted(choices)}")
         return v
 


### PR DESCRIPTION
### Motivation
- Loading saved JSON configs with `null` for optional typed CLI options caused typed converters (e.g. `int()`) to raise `TypeError`, so `null` should be preserved as `None` instead of being passed into type callables.

### Description
- Return `None` early from the internal `apply_type` so `None` values are not fed into the action `type` callable. 
- Skip `None` entries when validating list/append choice values so nullable list elements do not trigger choice errors. 
- Allow `None` for scalar choice checks by skipping choice validation when the coerced value is `None`.

### Testing
- Generated and saved a config with `--save-config` using `python3 ObstacleBridge.py ... --save-config ObstacleBridge.cfg` and loading it with `python3 ObstacleBridge.py -c ObstacleBridge.cfg --dump-config` succeeded. 
- Loading via module entrypoint with `PYTHONPATH=src python3 -m obstacle_bridge -c ObstacleBridge.cfg --dump-config` also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c35ada5b348322a3072f59fcce3239)