### PR TITLE
Persist admin-web config updates to config file

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -7591,6 +7591,45 @@ class Runner:
             })
         return {"peers": peers, "count": len(peers)}
 
+    def _group_config_snapshot(self, config: dict) -> dict:
+        sections = getattr(self.args, "_config_sections", {}) or {}
+        if not isinstance(sections, dict) or not sections:
+            return dict(config)
+        grouped: dict = {}
+        assigned: set = set()
+        for section in sorted(sections.keys()):
+            keys = sections.get(section, []) or []
+            block = {}
+            for key in keys:
+                if key in config:
+                    block[key] = config[key]
+            if block:
+                grouped[section] = block
+                assigned.update(block.keys())
+        misc = {k: v for k, v in config.items() if k not in assigned}
+        if misc:
+            grouped["misc"] = misc
+        return grouped
+
+    def save_runtime_config(self) -> tuple[bool, str]:
+        cfg_path = getattr(self.args, "config", None)
+        if not cfg_path:
+            return (True, "")
+        try:
+            path = pathlib.Path(str(cfg_path))
+            payload = self._group_config_snapshot(self.get_config_snapshot())
+            parent = path.parent
+            if parent and str(parent) not in ("", "."):
+                parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_name(path.name + ".tmp")
+            with tmp.open("w", encoding="utf-8") as f:
+                json.dump(payload, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+            tmp.replace(path)
+        except Exception as e:
+            return (False, f"failed to persist config to {cfg_path}: {e}")
+        return (True, "")
+
     def update_config(self, updates: dict) -> tuple[bool, str]:
         if not isinstance(updates, dict):
             return (False, "updates must be an object")
@@ -7618,7 +7657,7 @@ class Runner:
                 if not isinstance(value, (str, int, float, bool, list, dict)) and value is not None:
                     return (False, f"{key} has unsupported type")
             setattr(self.args, key, value)
-        return (True, "")
+        return self.save_runtime_config()
 
     def request_shutdown(self) -> None:
         self.log.debug("[SERVER] Runner shutdown requested")

--- a/tests/unit/test_runner_config_persistence.py
+++ b/tests/unit/test_runner_config_persistence.py
@@ -1,0 +1,30 @@
+import argparse
+import json
+
+from obstacle_bridge.bridge import Runner
+
+
+def _make_runner(tmp_path):
+    runner = Runner.__new__(Runner)
+    runner.args = argparse.Namespace(
+        config=str(tmp_path / "ObstacleBridge.cfg"),
+        admin_web_port=18080,
+        admin_web_bind="127.0.0.1",
+        overlay_transport="myudp",
+        _config_sections={"admin_web": ["admin_web_bind", "admin_web_port"]},
+    )
+    return runner
+
+
+def test_update_config_persists_to_config_file(tmp_path):
+    runner = _make_runner(tmp_path)
+
+    ok, err = runner.update_config({"admin_web_port": 18081})
+
+    assert ok is True
+    assert err == ""
+
+    written = json.loads((tmp_path / "ObstacleBridge.cfg").read_text(encoding="utf-8"))
+    assert written["admin_web"]["admin_web_port"] == 18081
+    assert written["admin_web"]["admin_web_bind"] == "127.0.0.1"
+    assert written["misc"]["overlay_transport"] == "myudp"


### PR DESCRIPTION
### Motivation
- The admin web UI allowed updating configuration via `/api/config` but changes were only applied in-memory and not written to the configured file, so edits were lost on restart. 
- The goal is to persist runtime admin updates to the `args.config` path so changes survive process restarts.

### Description
- Added a helper `Runner._group_config_snapshot` that groups flat config keys into sectioned structure using `args._config_sections` and places unassigned keys under `misc`.
- Implemented `Runner.save_runtime_config` to atomically write the grouped config JSON to the path from `args.config` using a temporary file then `replace` for safer persistence.
- Changed `Runner.update_config` to call `save_runtime_config` after applying validated updates so successful `/api/config` POSTs persist to disk.
- Added a unit test `tests/unit/test_runner_config_persistence.py` that verifies `Runner.update_config()` writes the updated values to `ObstacleBridge.cfg` and preserves other keys.

### Testing
- Ran `pytest -q tests/unit/test_runner_config_persistence.py` and it passed (`1 passed`).
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c36010ab908322861fe6e7599c3d92)