### PR TITLE
Align ws-session log override with websockets library loggers

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -8313,6 +8313,13 @@ class ConfigAwareCLI:
         self._log_object_attributes(args)
         self._log_registered_loggers()
 
+        # Keep third-party library logger names aligned with our section names.
+        # Example: "log_ws_session" should also control websockets' own logger
+        # hierarchy so the admin debug ring doesn't get flooded by frame dumps.
+        logger_aliases = {
+            "ws_session": ("websockets", "websockets.client", "websockets.server"),
+        }
+
         # Automatic section → logger name mapping
         # All section loggers become: runner.<section>
         for key, val in vars(args).items():
@@ -8333,6 +8340,11 @@ class ConfigAwareCLI:
             lg.setLevel(level)
 
             DebugLoggingConfigurator.debug_logger_status(lg)
+
+            for alias_name in logger_aliases.get(section, ()):
+                alias_logger = logging.getLogger(alias_name)
+                alias_logger.setLevel(level)
+                DebugLoggingConfigurator.debug_logger_status(alias_logger)
 
 
     def _log_registered_loggers(self)  -> None:

--- a/tests/unit/test_debug_logging_aliases.py
+++ b/tests/unit/test_debug_logging_aliases.py
@@ -1,0 +1,18 @@
+import argparse
+import logging
+
+from obstacle_bridge.bridge import ConfigAwareCLI, DebugLoggingConfigurator
+
+
+def test_log_ws_session_applies_to_websockets_library_loggers():
+    debug_cfg = DebugLoggingConfigurator(level_name="WARNING", console_level_name="CRITICAL")
+    debug_cfg.apply()
+
+    cfg = ConfigAwareCLI(description="test")
+    args = argparse.Namespace(log_ws_session="CRITICAL")
+    cfg._apply_per_section_overrides(args)
+
+    assert logging.getLogger("ws_session").level == logging.CRITICAL
+    assert logging.getLogger("websockets").level == logging.CRITICAL
+    assert logging.getLogger("websockets.client").level == logging.CRITICAL
+    assert logging.getLogger("websockets.server").level == logging.CRITICAL


### PR DESCRIPTION
### Motivation
- The admin web debug tab uses an in-memory handler that captures DEBUG-level records globally, which lets verbose `websockets.client` frame dumps appear even when `log_ws_session` is set to a higher level. 
- The per-section log override previously only set the internal `ws_session` logger and did not adjust third-party `websockets` loggers, causing the admin debug ring to be flooded.

### Description
- Add a `logger_aliases` mapping in `ConfigAwareCLI._apply_per_section_overrides` to map the `ws_session` section to `("websockets", "websockets.client", "websockets.server")`. 
- When a `log_<section>` override is applied the code now sets the level on both the section logger and any alias loggers and calls `DebugLoggingConfigurator.debug_logger_status` for each. 
- Add a unit test `tests/unit/test_debug_logging_aliases.py` that verifies `log_ws_session="CRITICAL"` propagates to `ws_session` and the `websockets` library loggers.

### Testing
- Ran the new unit test with `pytest -q tests/unit/test_debug_logging_aliases.py`, which passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c361dfada48322ba4aaf40baf7b891)