### PR TITLE
Improve admin config tab dropdown support for booleans and ws_payload_mode

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -303,9 +303,15 @@ function renderConfigRows(items, config) {
     const currentRaw = configValueToEditor(current);
     const defaultRaw = configValueToEditor(item.default);
     const isLevelSetting = isLoggingLevelSetting(key, current, item.default);
-    const editorHtml = isLevelSetting
-      ? renderLogLevelSelect(key, current)
-      : `<input class="config-editor mono" data-config-key="${key}" value="${currentRaw.replace(/"/g, '&quot;')}" />`;
+    const isBooleanSetting = isBooleanConfigSetting(current, item.default);
+    const hasChoices = Array.isArray(item.choices) && item.choices.length > 0;
+    const editorHtml = hasChoices
+      ? renderChoiceSelect(key, current, item.choices)
+      : (isBooleanSetting
+        ? renderBooleanSelect(key, current)
+        : (isLevelSetting
+          ? renderLogLevelSelect(key, current)
+          : `<input class="config-editor mono" data-config-key="${key}" value="${currentRaw.replace(/"/g, '&quot;')}" />`));
     return `
       <tr>
         <td class="mono">${key}</td>
@@ -382,6 +388,33 @@ function renderLogLevelSelect(key, currentValue) {
   const options = LOG_LEVEL_OPTIONS.map((level) => {
     const selected = level === normalizedCurrent ? ' selected' : '';
     return `<option value="${JSON.stringify(level).replace(/"/g, '&quot;')}"${selected}>${level}</option>`;
+  }).join('');
+  return `<select class="config-editor mono" data-config-key="${key}">${options}</select>`;
+}
+
+function isBooleanConfigSetting(currentValue, defaultValue) {
+  return typeof currentValue === 'boolean' || typeof defaultValue === 'boolean';
+}
+
+function renderBooleanSelect(key, currentValue) {
+  const normalizedCurrent = Boolean(currentValue);
+  const options = [true, false].map((value) => {
+    const selected = value === normalizedCurrent ? ' selected' : '';
+    return `<option value="${JSON.stringify(value)}"${selected}>${value}</option>`;
+  }).join('');
+  return `<select class="config-editor mono" data-config-key="${key}">${options}</select>`;
+}
+
+function renderChoiceSelect(key, currentValue, choices) {
+  const allowed = Array.isArray(choices) ? choices : [];
+  const fallbackChoices = allowed.some((choice) => JSON.stringify(choice) === JSON.stringify(currentValue))
+    ? allowed
+    : [...allowed, currentValue];
+  const options = fallbackChoices.map((choice) => {
+    const selected = JSON.stringify(choice) === JSON.stringify(currentValue) ? ' selected' : '';
+    const value = JSON.stringify(choice).replace(/"/g, '&quot;');
+    const label = typeof choice === 'string' ? choice : JSON.stringify(choice);
+    return `<option value="${value}"${selected}>${label}</option>`;
   }).join('');
   return `<select class="config-editor mono" data-config-key="${key}">${options}</select>`;
 }

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -7521,18 +7521,26 @@ class Runner:
         sections = getattr(self.args, "_config_sections", {}) or {}
         defaults = getattr(self.args, "_config_defaults", {}) or {}
         descriptions = getattr(self.args, "_config_help", {}) or {}
+        choices = getattr(self.args, "_config_choices", {}) or {}
 
         schema: dict = {}
         for section in sorted(sections.keys()):
+            section_keys = set(sections.get(section, []))
+            section_log_key = f"log_{section}"
+            if hasattr(self.args, section_log_key):
+                section_keys.add(section_log_key)
             items = []
-            for key in sorted(sections.get(section, [])):
+            for key in sorted(section_keys):
                 if not hasattr(self.args, key):
                     continue
-                items.append({
+                row = {
                     "key": key,
                     "description": descriptions.get(key, "(no description)"),
                     "default": defaults.get(key, None),
-                })
+                }
+                if key in choices:
+                    row["choices"] = list(choices.get(key, []))
+                items.append(row)
             if items:
                 schema[section] = items
         return schema
@@ -8192,6 +8200,7 @@ class ConfigAwareCLI:
         # and BEFORE we apply any JSON config.
         self._baseline_defaults: Dict[str, Any] = {}
         self._action_help: Dict[str, str] = {}
+        self._action_choices: Dict[str, List[Any]] = {}
 
     # ---------- public surface ----------
     def parse_args(
@@ -8295,12 +8304,16 @@ class ConfigAwareCLI:
         # 4) Snapshot defaults + help text (now that all options exist)
         self._baseline_defaults = {}
         self._action_help = {}
+        self._action_choices = {}
         for a in p._actions:
             d = getattr(a, "dest", None)
             if not d or d == "help":
                 continue
             self._baseline_defaults[d] = getattr(a, "default", None)
             self._action_help[d] = getattr(a, "help", "") or "(no description)"
+            choices = getattr(a, "choices", None)
+            if choices is not None:
+                self._action_choices[d] = list(choices)
 
         self._sections = sections
         self._parser = p
@@ -8636,6 +8649,7 @@ def main(argv: Optional[List[str]] = None) -> None:
     args._config_sections = {k: sorted(v) for k, v in cli.sections.items()}
     args._config_defaults = dict(cli._baseline_defaults)
     args._config_help = dict(cli._action_help)
+    args._config_choices = dict(cli._action_choices)
 
     # Apply logging in one line (behavior unchanged)
     DebugLoggingConfigurator.from_args(args).apply()


### PR DESCRIPTION
### Motivation
- Make the admin web configuration editor present appropriate pull-down editors instead of raw JSON inputs for common option types such as booleans and CLI-provided choice lists (e.g. `ws_payload_mode`).
- Ensure per-section log overrides (e.g. `log_admin_web`) appear in the schema so the admin UI can render and edit them.

### Description
- Updated the frontend `admin_web/app.js` to render select dropdowns when the schema provides `choices`, when a value or default is boolean, or when the key is a logging-level setting by reusing `renderLogLevelSelect` and adding `renderBooleanSelect`, `renderChoiceSelect`, and `isBooleanConfigSetting` helper functions, and wired those into `renderConfigRows`.
- Extended the config schema generator in `src/obstacle_bridge/bridge.py` to capture argparse `choices` for each action during parser construction and attach them to runtime args as `_config_choices`.
- Modified `Runner.get_config_schema_snapshot()` to include `choices` in each schema row and to explicitly add `log_<section>` keys (so `log_admin_web` is included) when the attribute exists on runtime args.
- Propagated the new parser metadata to `args._config_choices` so the admin UI can present authoritative dropdown options (additive change to the schema format).

### Testing
- Ran the unit test `python -m pytest -q tests/unit/test_runner_config_persistence.py` which passed (`1 passed`).
- Performed a schema smoke check using the runtime parser that verified `admin_web` contains `log_admin_web` and that `ws_payload_mode` includes choices `['base64', 'binary', 'json-base64']` (observed output: `True ['base64', 'binary', 'json-base64']`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c363f6d2548322be675ae2f3279399)