### PR TITLE
Fix restart loop in scripts/run.sh so admin restart relaunches bridge

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,6 +3,10 @@
 # Den gewünschten Befehl hier definieren
 COMMAND="./bin/python3 -m obstacle_bridge -c obstacle_bridge.cfg"
 
-until [ $? -eq 75 ]; do
+while true; do
   $COMMAND > /dev/null
+  rc=$?
+  if [ "$rc" -ne 75 ]; then
+    exit "$rc"
+  fi
 done


### PR DESCRIPTION
### Motivation
- The admin web `/api/restart` handler requests a restart by causing the runner to exit with code `75`, but the previous wrapper loop in `scripts/run.sh` exited when it saw `75` instead of relaunching the bridge.

### Description
- Replace the incorrect `until [ $? -eq 75 ]` loop with an unconditional `while true` loop that relaunches the command and only exits when the child process returns a code other than `75`, updating `scripts/run.sh` accordingly.

### Testing
- Verified shell syntax with `bash -n scripts/run.sh` and confirmed the script is syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c375c988748322ba0aca6cd7bdbefb)