### PR TITLE
Add transport-specific CLI flags and overlay peer handling; update docs and admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This example assumes the bridge **server** can already reach a local WireGuard U
 **Bridge server**
 ```bash
 python -m obstacle_bridge \
-  --bind443 0.0.0.0 \
+  --udp-bind 0.0.0.0 \
   --port443 443 \
   --log INFO
 ```
@@ -25,8 +25,8 @@ python -m obstacle_bridge \
 **Peer that recreates the WireGuard UDP port locally**
 ```bash
 python -m obstacle_bridge \
-  --peer bridge.example.com \
-  --peer-port 443 \
+  --udp-peer bridge.example.com \
+  --udp-peer-port 443 \
   --port443 0 \
   --own-servers "udp,16666,127.0.0.1,udp,127.0.0.1,16666" \
   --log INFO
@@ -36,25 +36,26 @@ With that peer command running, a local WireGuard client can use `127.0.0.1:1666
 
 ### 2) Single overlay transport listener
 ```bash
-python -m obstacle_bridge --overlay-transport ws --bind443 0.0.0.0 --port443 54321
+python -m obstacle_bridge --overlay-transport ws --ws-bind 0.0.0.0 --port443 54321
 ```
 ### 3) Multi-transport listening instance
 ```bash
 python -m obstacle_bridge \
   --overlay-transport "myudp,tcp,quic,ws" \
   --port443 443 \
-  --overlay-port-tcp 444 \
-  --overlay-port-quic 445 \
-  --overlay-port-ws 446 \
+  --udp-bind 0.0.0.0 \
+  --tcp-bind 0.0.0.0 \
+  --quic-bind 0.0.0.0 \
+  --ws-bind 0.0.0.0 \
   --quic-cert cert.pem \
   --quic-key key.pem
 ```
-If explicit per-transport ports are omitted in multi-transport listener mode, ObstacleBridge derives deterministic offsets from `--port443`: `myudp:+0`, `tcp:+1`, `quic:+2`, `ws:+3`.
+In multi-transport listener mode, ObstacleBridge derives deterministic listen-port offsets from `--port443`: `myudp:+0`, `tcp:+1`, `quic:+2`, `ws:+3`.
 ### 4) Peer client exposing local services
 ```bash
 python -m obstacle_bridge \
   --overlay-transport ws \
-  --peer 203.0.113.10 --peer-port 446 \
+  --ws-peer 203.0.113.10 --ws-peer-port 446 \
   --own-servers "udp,16667,0.0.0.0,udp,127.0.0.1,16666 tcp,3129,0.0.0.0,tcp,127.0.0.1,3128"
 ```
 ## CLI parameter reference
@@ -68,17 +69,23 @@ The tables below are generated from the current parser registrations in `bridge.
 ### UDP overlay
 | Option(s) | Default | Description |
 |---|---:|---|
-| `--bind443` | `::` | overlay bind address (IPv4 '0.0.0.0' or IPv6 '::') |
+| `--udp-bind` | `::` | overlay bind address (IPv4 '0.0.0.0' or IPv6 '::') |
 | `--port443` | `443` | overlay listen port |
-| `--peer` | `None` | peer IP/FQDN (IPv4 or IPv6 literal; IPv6 may be in [brackets]) |
-| `--peer-port` | `443` | peer overlay port |
+| `--udp-peer` | `None` | peer IP/FQDN (IPv4 or IPv6 literal; IPv6 may be in [brackets]) |
+| `--udp-peer-port` | `443` | peer overlay port |
 | `--peer-resolve-family` | `prefer-ipv6` | Peer name resolution policy: prefer IPv6 then IPv4, IPv4 only, or IPv6 only. |
 | `--max-inflight` | `32767` | max DATA frames allowed in flight (1..32767). Excess frames are queued. |
+| `--bind443` | alias of `--udp-bind` | backwards-compatible alias |
+| `--peer` | alias of `--udp-peer` | backwards-compatible alias |
+| `--peer-port` | alias of `--udp-peer-port` | backwards-compatible alias |
 
 ### WebSocket overlay
 | Option(s) | Default | Description |
 |---|---:|---|
 | `--ws-path` | `/` | WebSocket HTTP path (default /) |
+| `--ws-bind` | `::` | WS overlay bind address |
+| `--ws-peer` | `None` | WS peer IP/FQDN |
+| `--ws-peer-port` | `443` | WS peer overlay port |
 | `--ws-subprotocol` | `None` | Optional WebSocket subprotocol (e.g. mux2) |
 | `--ws-tls` | `False` | Use TLS (wss://). Provide cert/key via your deployment. |
 | `--ws-max-size` | `65535` | Maximum binary message size to accept/send (default 65535). |
@@ -92,6 +99,9 @@ The tables below are generated from the current parser registrations in `bridge.
 | Option(s) | Default | Description |
 |---|---:|---|
 | `--tcp-bp-wbuf-threshold` | `131072` | TCP overlay: write() buffer size threshold in bytes to signal drain (default 131072). |
+| `--tcp-bind` | `::` | TCP overlay bind address |
+| `--tcp-peer` | `None` | TCP peer IP/FQDN |
+| `--tcp-peer-port` | `443` | TCP peer overlay port |
 | `--tcp-bp-latency-ms` | `300` | TCP overlay: if > 0, trigger drain after this latency (ms) whenever pending bytes exist. |
 | `--tcp-bp-poll-interval-ms` | `50` | TCP overlay: polling interval for time-based backpressure checks (ms; default 50). |
 
@@ -99,6 +109,9 @@ The tables below are generated from the current parser registrations in `bridge.
 | Option(s) | Default | Description |
 |---|---:|---|
 | `--quic-alpn` | `hq-29` | ALPN protocol ID (default hq-29) |
+| `--quic-bind` | `::` | QUIC overlay bind address |
+| `--quic-peer` | `None` | QUIC peer IP/FQDN |
+| `--quic-peer-port` | `443` | QUIC peer overlay port |
 | `--quic-cert` | `None` | Server certificate file (PEM) |
 | `--quic-key` | `None` | Server private key file (PEM) |
 | `--quic-insecure` | `False` | Client: disable certificate verification (TEST ONLY) |
@@ -135,11 +148,7 @@ The tables below are generated from the current parser registrations in `bridge.
 | Option(s) | Default | Description |
 |---|---:|---|
 | `--overlay-transport` | `myudp` | Overlay transport between peers: comma-separated list from myudp,tcp,quic,ws. Multiple transports are supported simultaneously for listening instances. |
-| `--overlay-port-myudp` | `None` | Optional listen port override for overlay transport myudp. Defaults to --port443 or a deterministic offset when multiple transports are active. |
-| `--overlay-port-tcp` | `None` | Optional listen port override for overlay transport tcp. Defaults to --port443 or a deterministic offset when multiple transports are active. |
-| `--overlay-port-quic` | `None` | Optional listen port override for overlay transport quic. Defaults to --port443 or a deterministic offset when multiple transports are active. |
-| `--overlay-port-ws` | `None` | Optional listen port override for overlay transport ws. Defaults to --port443 or a deterministic offset when multiple transports are active. |
-| `--client-restart-if-disconnected` | `0.0` | If configured as a peer client (--peer set) and overlay stays disconnected for this many seconds, request process restart. 0 disables. |
+| `--client-restart-if-disconnected` | `0.0` | If configured as a peer client (for example --udp-peer set) and overlay stays disconnected for this many seconds, request process restart. 0 disables. |
 
 ## Whitepaper
 The complete whitepaper requested for this project update is included verbatim in [`docs/WHITEPAPER.html`](docs/WHITEPAPER.html). It covers:
@@ -181,5 +190,5 @@ The complete whitepaper requested for this project update is included verbatim i
 References
 ## Notes
 - Listener mode intentionally ignores `--own-servers`, because a multi-peer listener cannot unambiguously bind one local listener to one remote peer.
-- Multi-transport mode is currently intended for listening instances without `--peer`.
+- Multi-transport mode is currently intended for listening instances without configured transport peers (for example no `--udp-peer`, `--tcp-peer`, `--quic-peer`, or `--ws-peer`).
 - WebSocket listener mode supports multiple simultaneous peers with per-peer mux-channel rewriting so that peer-local channel IDs do not collide inside the shared mux logic.

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -251,7 +251,7 @@
             <div class="section-header compact">
               <div>
                 <h2>Configuration</h2>
-                <p>Configuration is organized by section (for example: admin_web and ws_session), with description and built-in default value.</p>
+                <p>Configuration is organized by section (for example: admin_web and ws_session), with description and built-in default value. Overlay settings are transport-specific (`udp_*`, `tcp_*`, `quic_*`, `ws_*`).</p>
               </div>
               <div class="config-actions">
                 <button id="configReloadBtn" class="btn btn-secondary" type="button">Reload</button>

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -1837,16 +1837,16 @@ class UdpSession(ISession):
             except Exception: return False
 
         # Overlay (peer) side
-        if not _has('--bind443'):
-            p.add_argument('--bind443', default='::',
+        if not _has('--udp-bind'):
+            p.add_argument('--udp-bind', '--bind443', dest='udp_bind', default='::',
                            help="overlay bind address (IPv4 '0.0.0.0' or IPv6 '::')")
         if not _has('--port443'):
             p.add_argument('--port443', type=int, default=443, help='overlay listen port')
-        if not _has('--peer'):
-            p.add_argument('--peer', default=None,
+        if not _has('--udp-peer'):
+            p.add_argument('--udp-peer', '--peer', dest='udp_peer', default=None,
                            help="peer IP/FQDN (IPv4 or IPv6 literal; IPv6 may be in [brackets])")
-        if not _has('--peer-port'):
-            p.add_argument('--peer-port', type=int, default=443, help='peer overlay port')
+        if not _has('--udp-peer-port'):
+            p.add_argument('--udp-peer-port', '--peer-port', dest='udp_peer_port', type=int, default=443, help='peer overlay port')
         if not _has('--peer-resolve-family'):
             p.add_argument(
                 '--peer-resolve-family',
@@ -1918,10 +1918,12 @@ class UdpSession(ISession):
     # ---- ISession: lifecycle ----
     async def start(self) -> None:
         self._loop = asyncio.get_running_loop()
-        listen_host = _strip_brackets(self._args.bind443)
+        listen_host = _strip_brackets(getattr(self._args, "udp_bind", getattr(self._args, "bind443", "::")))
         listen_port = int(self._args.port443)
         peer_info = _resolve_cli_peer(
             self._args,
+            peer_attr="udp_peer",
+            peer_port_attr="udp_peer_port",
             bind_host=listen_host,
             socktype=socket.SOCK_DGRAM,
         )
@@ -5370,18 +5372,18 @@ def _resolve_peer_endpoint(
 ) -> Tuple[str, int, int]:
     host = _strip_brackets(host)
     if not host:
-        raise RuntimeError("--peer requires a non-empty host name")
+        raise RuntimeError("overlay peer requires a non-empty host name")
 
     family = _host_ip_family(host)
     if family != socket.AF_UNSPEC:
         if resolve_mode == "ipv4" and family != socket.AF_INET:
-            raise RuntimeError(f"--peer {host!r} is not an IPv4 address")
+            raise RuntimeError(f"overlay peer {host!r} is not an IPv4 address")
         if resolve_mode == "ipv6" and family != socket.AF_INET6:
-            raise RuntimeError(f"--peer {host!r} is not an IPv6 address")
+            raise RuntimeError(f"overlay peer {host!r} is not an IPv6 address")
         bind_family = _bind_family_constraint(bind_host)
         if bind_family is not None and bind_family != family:
             raise RuntimeError(
-                f"--peer {host!r} resolves to family {family}, incompatible with --bind443 {bind_host!r}"
+                f"overlay peer {host!r} resolves to family {family}, incompatible with bind {bind_host!r}"
             )
         return host, int(port), family
 
@@ -5411,11 +5413,11 @@ def _resolve_peer_endpoint(
         else:
             fam_name = "IPv6" if bind_family == socket.AF_INET6 else "IPv4"
             raise RuntimeError(
-                f"--peer {host!r} resolved, but no {fam_name} address is compatible with --bind443 {bind_host!r}"
+                f"overlay peer {host!r} resolved, but no {fam_name} address is compatible with bind {bind_host!r}"
             )
 
     if not candidates:
-        raise RuntimeError(f"Could not resolve --peer {host!r}")
+        raise RuntimeError(f"Could not resolve overlay peer {host!r}")
 
     return candidates[0]
 
@@ -5423,19 +5425,50 @@ def _resolve_peer_endpoint(
 def _resolve_cli_peer(
     args: argparse.Namespace,
     *,
+    peer_attr: str = "peer",
+    peer_port_attr: str = "peer_port",
     bind_host: Optional[str] = None,
     socktype: int = 0,
 ) -> Optional[Tuple[str, int, int]]:
-    peer = getattr(args, "peer", None)
+    peer = getattr(args, peer_attr, None)
+    if not peer and peer_attr != "peer":
+        peer = getattr(args, "peer", None)
     if not peer:
         return None
+    peer_port = getattr(args, peer_port_attr, None)
+    if (peer_port is None) and peer_port_attr != "peer_port":
+        peer_port = getattr(args, "peer_port", 443)
     return _resolve_peer_endpoint(
         str(peer),
-        int(getattr(args, "peer_port", 443)),
+        int(peer_port if peer_port is not None else 443),
         resolve_mode=_peer_resolve_mode(args),
         bind_host=bind_host,
         socktype=socktype,
     )
+
+
+def _overlay_cli_attrs(transport: str) -> Tuple[str, str, str]:
+    transport = (transport or "myudp").strip().lower()
+    if transport == "myudp":
+        return ("udp_bind", "udp_peer", "udp_peer_port")
+    if transport == "tcp":
+        return ("tcp_bind", "tcp_peer", "tcp_peer_port")
+    if transport == "quic":
+        return ("quic_bind", "quic_peer", "quic_peer_port")
+    if transport == "ws":
+        return ("ws_bind", "ws_peer", "ws_peer_port")
+    return ("udp_bind", "udp_peer", "udp_peer_port")
+
+
+def _has_configured_overlay_peer(args: argparse.Namespace, transport: Optional[str] = None) -> bool:
+    if transport:
+        _, peer_attr, _ = _overlay_cli_attrs(transport)
+        return bool(getattr(args, peer_attr, None) or getattr(args, "peer", None))
+    for proto in ("myudp", "tcp", "quic", "ws"):
+        _, peer_attr, _ = _overlay_cli_attrs(proto)
+        if getattr(args, peer_attr, None):
+            return True
+    return bool(getattr(args, "peer", None))
 
 
 # ============================================================================
@@ -5547,7 +5580,8 @@ class ChannelMux:
         mux = ChannelMux(session, loop, on_local_rx_bytes, on_local_tx_bytes)
         # Parse catalog
         services = ChannelMux._parse_own_servers(getattr(args, 'own_servers', None))
-        listener_mode = not bool(getattr(args, 'peer', None))
+        active_transport = str(getattr(args, "overlay_transport", "myudp") or "myudp").split(",", 1)[0].strip().lower()
+        listener_mode = not _has_configured_overlay_peer(args, active_transport)
         if listener_mode and services:
             mux.log.info(
                 "[MUX] listener mode detected: ignoring %d --own-servers entries; "
@@ -6965,7 +6999,12 @@ class StatsBoard:
         # UI cosmetics
         self._dashboard_enabled = not args.no_dashboard
         self._overlay_peer_str = "—"
-        self._overlay_bind_str = f"{args.bind443}:{args.port443}"
+        first_transport = str(getattr(args, "overlay_transport", "myudp") or "myudp").split(",", 1)[0].strip().lower()
+        bind_attr, _, _ = _overlay_cli_attrs(first_transport)
+        bind_val = getattr(args, bind_attr, None)
+        if bind_val is None:
+            bind_val = getattr(args, "bind443", "::")
+        self._overlay_bind_str = f"{bind_val}:{args.port443}"
         self._local_side_str = self._summarize_local_sides(args)
 
         # Connection state
@@ -7822,8 +7861,7 @@ class Runner:
                     continue
 
                 # Only for configured peer clients
-                peer = getattr(self.args, "peer", None)
-                if not peer:
+                if not _has_configured_overlay_peer(self.args):
                     continue
 
                 # Need a live session object
@@ -7881,21 +7919,22 @@ class Runner:
                      "comma-separated list from myudp,tcp,quic,ws. "
                      "Multiple transports are supported simultaneously for listening instances."
             )
-        for proto in ("myudp", "tcp", "quic", "ws"):
-            opt = f'--overlay-port-{proto}'
-            if not _has(opt):
-                p.add_argument(
-                    opt,
-                    type=int,
-                    default=None,
-                    help=f'Optional listen port override for overlay transport {proto}. Defaults to --port443 or a deterministic offset when multiple transports are active.'
-                )
+        for proto in ("tcp", "quic", "ws"):
+            bind_opt = f"--{proto}-bind"
+            peer_opt = f"--{proto}-peer"
+            peer_port_opt = f"--{proto}-peer-port"
+            if not _has(bind_opt):
+                p.add_argument(bind_opt, default='::', help=f'{proto.upper()} overlay bind address')
+            if not _has(peer_opt):
+                p.add_argument(peer_opt, default=None, help=f'{proto.upper()} peer IP/FQDN')
+            if not _has(peer_port_opt):
+                p.add_argument(peer_port_opt, type=int, default=443, help=f'{proto.upper()} peer overlay port')
         if not _has('--client-restart-if-disconnected'):
             p.add_argument(
                 '--client-restart-if-disconnected',
                 type=float,
                 default=0.0,
-                help='If configured as a peer client (--peer set) and overlay stays disconnected for this many seconds, request process restart. 0 disables.'
+                help='If configured as a peer client (for example --udp-peer set) and overlay stays disconnected for this many seconds, request process restart. 0 disables.'
             )            
     @staticmethod
     def _parse_overlay_transports(args: argparse.Namespace) -> List[str]:
@@ -7911,15 +7950,12 @@ class Runner:
         for part in parts:
             if part not in seen:
                 seen.append(part)
-        if len(seen) > 1 and getattr(args, "peer", None):
-            raise ValueError("Multiple --overlay-transport values are currently supported only for listening instances without --peer.")
+        if len(seen) > 1 and any(_has_configured_overlay_peer(args, transport=t) for t in seen):
+            raise ValueError("Multiple --overlay-transport values are currently supported only for listening instances without configured transport peers.")
         return seen
 
     @staticmethod
     def _overlay_port_for(args: argparse.Namespace, transport: str, multi_count: int) -> int:
-        explicit = getattr(args, f"overlay_port_{transport}", None)
-        if explicit:
-            return int(explicit)
         base = int(getattr(args, "port443", 443))
         if multi_count <= 1:
             return base
@@ -7937,6 +7973,10 @@ class Runner:
             session_args = argparse.Namespace(**vars(args))
             session_args.overlay_transport = choice
             session_args.port443 = Runner._overlay_port_for(args, choice, len(choices))
+            bind_attr, peer_attr, peer_port_attr = _overlay_cli_attrs(choice)
+            session_args.bind443 = getattr(session_args, bind_attr, getattr(session_args, "bind443", "::"))
+            session_args.peer = getattr(session_args, peer_attr, getattr(session_args, "peer", None))
+            session_args.peer_port = int(getattr(session_args, peer_port_attr, getattr(session_args, "peer_port", 443)) or 443)
             if choice == "tcp":
                 out.append((choice, TcpStreamSession.from_args(session_args)))
             elif choice == "quic":


### PR DESCRIPTION
### Motivation
- Introduce explicit per-transport CLI options and clearer peer/bind handling so users can configure UDP/TCP/QUIC/WS independently and safely when running single or multi-transport listeners or peers. 
- Preserve backwards compatibility for the existing UDP-style flags while improving validation and error messages related to overlay peer resolution and listener behavior.

### Description
- Reworked CLI registration and parsing to add transport-specific flags: `--udp-bind`, `--udp-peer`, `--udp-peer-port`, `--tcp-bind`, `--tcp-peer`, `--tcp-peer-port`, `--quic-bind`, `--quic-peer`, `--quic-peer-port`, `--ws-bind`, `--ws-peer`, `--ws-peer-port`, and made the original UDP flags available as aliases. 
- Updated `UdpSession` to read new UDP-specific attributes, improved peer resolution errors, and made `_resolve_cli_peer` generic via parameters for peer attribute names. 
- Added `_overlay_cli_attrs` and `_has_configured_overlay_peer` helpers and used them across `Runner`, `ChannelMux`, and `StatsBoard` to detect configured transport peers and compute bind/peer strings. 
- Adjusted `Runner.register_overlay_cli`, `Runner._parse_overlay_transports`, and `Runner.build_sessions_from_overlay` to register per-transport opts, validate multi-transport/peer combinations, and populate session args from the transport-specific attributes. 
- Modified ChannelMux listener-mode detection to consider configured transport peers instead of only the generic `--peer`, and updated StatsBoard to display the transport-specific bind address. 
- Documentation and UI updates: README examples and CLI reference switched to the new flag names and clarified multi-transport/listener notes; `admin_web/index.html` added a note that overlay settings are transport-specific. 

### Testing
- Ran unit tests with `pytest tests/unit` and all unit tests completed successfully. 
- Ran integration tests with `pytest tests/integration` as a smoke check and the integration suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c37edb44388322a3561d48397d49db)