### PR TITLE
Expand admin config class boxes to remove internal vertical scrolling

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -331,7 +331,7 @@ function renderConfigCard(title, rowsHtml) {
           <h3>${title}</h3>
         </div>
       </div>
-      <div class="table-wrap">
+      <div class="table-wrap config-table-wrap">
         <table class="conn-table">
           <thead>
             <tr>

--- a/admin_web/style.css
+++ b/admin_web/style.css
@@ -531,6 +531,11 @@ h1 {
   overflow-y: auto;
 }
 
+.config-table-wrap {
+  max-height: none;
+  overflow-y: visible;
+}
+
 .conn-table thead th {
   position: sticky;
   top: 0;


### PR DESCRIPTION
### Motivation
- Configuration class tables in the admin UI were capped with a vertical height and internal scrollbar, which hid parameters; the goal is to allow config boxes to expand so all parameters are visible without an internal vertical scroll.

### Description
- Mark configuration table containers with a dedicated wrapper class by adding `config-table-wrap` to the table wrapper in `admin_web/app.js`.
- Add a CSS override for `.config-table-wrap` in `admin_web/style.css` to remove the `max-height: 420px` constraint and make `overflow-y: visible` so config boxes expand to fit their contents.
- Preserve the existing `.table-wrap` behavior for other tables so status/connection views retain horizontal/vertical scrolling behavior on constrained screens.

### Testing
- Verified the change via `git diff` to confirm `admin_web/app.js` and `admin_web/style.css` were updated as intended and the new class is present in the rendered markup.
- Ran `git status --short` and successfully committed the change with the message `admin web: expand config class boxes to avoid scrollbars` to record the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c38635c44c8322b5befb7415d7c46e)