### PR TITLE
Handle localhost peer resolution failures when DNS lacks records

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -5371,6 +5371,15 @@ def _wildcard_host_for_family(family: int) -> str:
     return "::" if family == socket.AF_INET6 else "0.0.0.0"
 
 
+def _localhost_fallback(resolve_mode: str) -> Optional[Tuple[str, int]]:
+    mode = (resolve_mode or "").strip().lower()
+    if mode == "ipv4":
+        return ("127.0.0.1", socket.AF_INET)
+    if mode == "ipv6":
+        return ("::1", socket.AF_INET6)
+    return None
+
+
 def _prefer_unspec_listener_family() -> bool:
     """
     Python 3.9 needs explicit AF_INET/AF_INET6 in several asyncio listener paths.
@@ -5417,7 +5426,14 @@ def _resolve_peer_endpoint(
     elif resolve_mode == "ipv6":
         lookup_family = socket.AF_INET6
 
-    infos = socket.getaddrinfo(host, int(port), family=lookup_family, type=socktype)
+    try:
+        infos = socket.getaddrinfo(host, int(port), family=lookup_family, type=socktype)
+    except socket.gaierror as exc:
+        localhost_fallback = _localhost_fallback(resolve_mode)
+        if localhost_fallback and host.lower() == "localhost":
+            fallback_host, fallback_family = localhost_fallback
+            return fallback_host, int(port), fallback_family
+        raise RuntimeError(f"Could not resolve overlay peer {host!r}: {exc}") from exc
     candidates: List[Tuple[str, int, int]] = []
     for fam, _socktype, _proto, _canonname, sockaddr in infos:
         if fam not in (socket.AF_INET, socket.AF_INET6):

--- a/tests/unit/test_peer_resolution.py
+++ b/tests/unit/test_peer_resolution.py
@@ -1,0 +1,32 @@
+import socket
+
+import pytest
+
+from obstacle_bridge.bridge import _resolve_peer_endpoint
+
+
+def test_resolve_localhost_ipv6_uses_loopback_fallback_on_gaierror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _always_fail(*_args, **_kwargs):
+        raise socket.gaierror(-5, "No address associated with hostname")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _always_fail)
+    host, port, family = _resolve_peer_endpoint("localhost", 443, resolve_mode="ipv6", socktype=socket.SOCK_STREAM)
+    assert (host, port, family) == ("::1", 443, socket.AF_INET6)
+
+
+def test_resolve_localhost_ipv4_uses_loopback_fallback_on_gaierror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _always_fail(*_args, **_kwargs):
+        raise socket.gaierror(-5, "No address associated with hostname")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _always_fail)
+    host, port, family = _resolve_peer_endpoint("localhost", 443, resolve_mode="ipv4", socktype=socket.SOCK_DGRAM)
+    assert (host, port, family) == ("127.0.0.1", 443, socket.AF_INET)
+
+
+def test_resolve_non_localhost_propagates_resolution_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _always_fail(*_args, **_kwargs):
+        raise socket.gaierror(-2, "Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _always_fail)
+    with pytest.raises(RuntimeError, match="Could not resolve overlay peer 'example.invalid'"):
+        _resolve_peer_endpoint("example.invalid", 443, resolve_mode="ipv4", socktype=socket.SOCK_STREAM)


### PR DESCRIPTION
### Motivation

- DNS lookups for `localhost` can fail in environments missing A/AAAA records, causing `socket.gaierror` and test failures when `--peer-resolve-family` is strict.
- An integration run showed bridge clients exiting early with `socket.gaierror: No address associated with hostname`, so the peer resolution needs a deterministic localhost fallback for ipv4/ipv6 modes.

### Description

- Add `_localhost_fallback(resolve_mode)` helper that maps `ipv4` to `127.0.0.1`/`AF_INET` and `ipv6` to `::1`/`AF_INET6` in `src/obstacle_bridge/bridge.py`.
- Catch `socket.gaierror` in `_resolve_peer_endpoint()` and, when the host is `localhost` and a strict `resolve_mode` is set, return the appropriate loopback address instead of propagating the raw `gaierror`.
- Preserve a clear `RuntimeError` for non-`localhost` resolution failures so other name resolution errors still surface to callers.
- Add unit tests in `tests/unit/test_peer_resolution.py` to assert ipv4/ipv6 localhost fallback behavior and verify non-localhost failures raise `RuntimeError`.

### Testing

- Ran `pytest -q tests/unit/test_peer_resolution.py` and observed `3 passed`.
- Ran targeted integration smoke case `python tests/integration/test_overlay_e2e_reconnect.py --cases case01_udp_over_own_udp_localhost_ipv6` and observed the case passed in the harness.
- Existing failing e2e scenarios related to non-localhost resolution continue to raise explicit `RuntimeError`s per the new behavior (validated by unit tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c39d0294848322aae448ccc8c431d2)