### PR TITLE
Fix WebSocket early-buffer TX callback delivery on flush

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -3663,7 +3663,7 @@ class QuicSession(ISession):
         self._log_counters("UPDATE")
 
     # ---- early buffer ----
-    def _buffer_early(self, wire: bytes) -> None:
+    def _buffer_early(self, wire: bytes, on_sent: Optional[Callable[[], None]] = None) -> None:
         now = time.time()
         if self._early_deadline and now > self._early_deadline:
             self._log.info(f"[QUIC/TX] ({self._probe_id}) early-buf TTL expired; discarding {len(self._early_buf)}B")
@@ -3919,7 +3919,7 @@ class WebSocketSession(ISession):
         self._server_next_mux_chan: int = 1
 
         # Early buffer (APP/CTRL frames preserved as individual WS messages)
-        self._early_buf: Deque[bytes] = deque()
+        self._early_buf: Deque[tuple[bytes, Optional[Callable[[], None]]]] = deque()
         self._early_buf_bytes = 0
         self._early_max = 1 * 1024 * 1024
         self._early_ttl = 3.0
@@ -4070,7 +4070,7 @@ class WebSocketSession(ISession):
             return len(payload)
 
         if self._ws is None:
-            self._buffer_early(wire)
+            self._buffer_early(wire, on_sent=lambda: self._notify_peer_tx(len(wire)))
             self._log.debug(f"[WS/TX] ({self._probe_id}) early-buffer APP bytes={len(wire)} buf={len(self._early_buf)}")
             if self._peer_tuple:
                 self._ensure_connect_once()
@@ -4882,7 +4882,7 @@ class WebSocketSession(ISession):
         self._log_counters("UPDATE")
 
     # --- early buffer ----------------------------------------------------------
-    def _buffer_early(self, wire: bytes) -> None:
+    def _buffer_early(self, wire: bytes, on_sent: Optional[Callable[[], None]] = None) -> None:
         now = time.time()
         if self._early_deadline and now > self._early_deadline:
             self._log.info(f"[WS/TX] ({self._probe_id}) early-buf TTL expired; discarding {self._early_buf_bytes}B")
@@ -4890,10 +4890,10 @@ class WebSocketSession(ISession):
             self._early_buf_bytes = 0
         self._early_deadline = now + self._early_ttl
 
-        self._early_buf.append(bytes(wire))
+        self._early_buf.append((bytes(wire), on_sent))
         self._early_buf_bytes += len(wire)
         while self._early_buf_bytes > self._early_max and self._early_buf:
-            dropped = self._early_buf.popleft()
+            dropped, _ = self._early_buf.popleft()
             self._early_buf_bytes -= len(dropped)
             self._log.info(
                 f"[WS/TX] ({self._probe_id}) early-buf capped: dropped={len(dropped)} keep={self._early_buf_bytes} cap={self._early_max}"
@@ -4907,8 +4907,8 @@ class WebSocketSession(ISession):
             self._log.info(
                 f"[WS/TX] ({self._probe_id}) flushing early-buf frames={len(pending)} bytes={self._early_buf_bytes}"
             )
-            for wire in pending:
-                self._schedule_send(wire)
+            for wire, on_sent in pending:
+                self._schedule_send(wire, on_sent=on_sent)
         except Exception as e:
             self._log.info(f"[WS/TX] ({self._probe_id}) flush error: {e!r}")
         finally:

--- a/tests/unit/test_ws_payload_mode.py
+++ b/tests/unit/test_ws_payload_mode.py
@@ -189,19 +189,45 @@ class WebSocketPayloadModeTests(unittest.TestCase):
         session = WebSocketSession(_args("binary"))
         session._ws = object()
         sent = []
-        session._schedule_send = sent.append
+        session._schedule_send = lambda wire, on_sent=None: sent.append((wire, on_sent))
         session._bump_tx = lambda wire: None
         session._buffer_early(b"\x01first")
         session._buffer_early(b"\x02second")
 
         session._flush_early()
 
-        self.assertEqual(sent, [b"\x01first", b"\x02second"])
+        self.assertEqual([wire for wire, _ in sent], [b"\x01first", b"\x02second"])
+        self.assertEqual([on_sent for _, on_sent in sent], [None, None])
         self.assertEqual(len(session._early_buf), 0)
         self.assertEqual(session._early_buf_bytes, 0)
 
 
 class WebSocketTxLoopTests(unittest.IsolatedAsyncioTestCase):
+    async def test_early_buffered_send_notifies_peer_tx_after_flush(self):
+        args = _args("binary")
+        args.peer = "127.0.0.1"
+        args.peer_port = 54321
+        session = WebSocketSession(args)
+        session._loop = asyncio.get_running_loop()
+        session._peer_tuple = ("127.0.0.1", 54321)
+        sent_sizes = []
+        session.set_on_peer_tx(sent_sizes.append)
+
+        session._ws = None
+        session.send_app(b"hello")
+        self.assertEqual(session._early_buf_bytes, 6)
+
+        session._ws = _FakeWs()
+        session._flush_early()
+        await asyncio.wait_for(session._tx_queue.join(), timeout=1.0)
+
+        self.assertEqual(session._tx_bytes, 6)
+        self.assertEqual(sent_sizes, [6])
+        self.assertEqual(session._ws.sent, [b"\x00hello"])
+
+        session._tx_task.cancel()
+        await session._tx_task
+
     async def test_tx_accounting_happens_after_successful_send(self):
         session = WebSocketSession(_args("binary"))
         session._loop = asyncio.get_running_loop()


### PR DESCRIPTION
### Motivation
- Early-buffered WebSocket APP frames dropped their `on_sent` callbacks, so peer TX accounting/notifications were never emitted after reconnect and flush.
- The change aligns buffered-send behavior with the post-send accounting model so metrics and callbacks occur only after a successful send.

### Description
- Change WebSocket session early buffer to store `(wire, on_sent)` tuples and update `_buffer_early` to accept an optional `on_sent` callback parameter.
- Preserve and deliver stored callbacks during `_flush_early` by passing `on_sent` when scheduling sends.
- Route client `send_app` early-buffering through `_buffer_early(..., on_sent=...)` so `_notify_peer_tx` is invoked after successful flush/send.
- Update `tests/unit/test_ws_payload_mode.py` to adapt `session._schedule_send` usage and add a test that verifies early-buffered client sends notify peer TX after flush.

### Testing
- Ran `pytest -q tests/unit/test_ws_payload_mode.py`, which passed (`18 passed`).
- Ran the full suite with `pytest -q`, which passed (`34 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3b07f1e888322999b127f64a0a8b7)