### PR TITLE
admin web: remove transport health panel

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -98,7 +98,6 @@ function renderConnectionTable(tbodyId, rows) {
 function applyPeerState(state) {
   const badge = document.getElementById('peerStateBadge');
   const normalized = String(state || 'UNKNOWN').toUpperCase();
-  setText('peerState', normalized);
   if (!badge) return;
 
   badge.textContent = normalized;
@@ -141,9 +140,6 @@ async function loadStatus() {
     const j = await r.json();
 
     applyPeerState(j.peer_state);
-    setText('detailOverlayBind', j.overlay?.bind ?? 'n/a');
-    setText('detailOverlayPeer', j.overlay?.peer ?? 'n/a');
-
     setText('udpOpen', fmtInteger(j.open_connections?.udp));
     setText('tcpOpen', fmtInteger(j.open_connections?.tcp));
 

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -95,22 +95,6 @@
             </div>
           </section>
 
-          <div class="two-col">
-            <section class="section-block card">
-              <div class="section-header compact">
-                <div>
-                  <h2>Transport Health</h2>
-                  <p>Current live transport indicators</p>
-                </div>
-              </div>
-              <div class="detail-grid">
-                <div class="detail-row"><span>Peer State</span><strong id="peerState">n/a</strong></div>
-                <div class="detail-row"><span>Overlay Bind</span><strong id="detailOverlayBind">n/a</strong></div>
-                <div class="detail-row"><span>Overlay Peer</span><strong id="detailOverlayPeer">n/a</strong></div>
-              </div>
-            </section>
-          </div>
-
           <section class="section-block">
             <div class="section-header">
               <div>


### PR DESCRIPTION
### Motivation
- Simplify the admin dashboard by removing the Transport Health card and the associated per-panel UI fields that are no longer needed.

### Description
- Deleted the Transport Health section from `admin_web/index.html` and removed corresponding UI updates in `admin_web/app.js` (removed `setText('peerState', ...)`, `setText('detailOverlayBind', ...)`, and `setText('detailOverlayPeer', ...)` while keeping the peer state badge update logic).

### Testing
- Ran `rg -n "peerState|detailOverlayBind|detailOverlayPeer|Transport Health" admin_web -S` to verify the transport health fields were removed, which returned only the remaining `peerStateBadge` reference indicating the panel and detail fields were removed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5117331b88322b6877a70f66d1984)