### PR TITLE
Add regression coverage for websocket early-buffer flush behavior

### DIFF
--- a/tests/unit/test_ws_payload_mode.py
+++ b/tests/unit/test_ws_payload_mode.py
@@ -220,6 +220,8 @@ class WebSocketTxLoopTests(unittest.IsolatedAsyncioTestCase):
         session._ws = _FakeWs()
         session._flush_early()
         await asyncio.wait_for(session._tx_queue.join(), timeout=1.0)
+        session._flush_early()
+        await asyncio.wait_for(session._tx_queue.join(), timeout=1.0)
 
         self.assertEqual(session._tx_bytes, 6)
         self.assertEqual(sent_sizes, [6])


### PR DESCRIPTION
### Motivation
- Ensure the WebSocket send-accounting behavior remains correct when `_flush_early()` is invoked more than once (protects the fix from regressions when branches are rebased/merged). 

### Description
- Update `test_early_buffered_send_notifies_peer_tx_after_flush` in `tests/unit/test_ws_payload_mode.py` to call `_flush_early()` twice and await the tx queue after each call to assert that frames and transmit accounting are only applied once. 

### Testing
- Ran `pytest -q tests/unit/test_ws_payload_mode.py` which passed (`18 passed`).
- Ran full test suite with `pytest -q` which passed (`34 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5329edef8832296caf98220774c50)