### PR TITLE
Add zero-grace websocket reconnect regression test

### DIFF
--- a/tests/unit/test_ws_payload_mode.py
+++ b/tests/unit/test_ws_payload_mode.py
@@ -284,6 +284,19 @@ class WebSocketSocketConfigTests(unittest.TestCase):
 
 
 class WebSocketReconnectGraceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_zero_grace_disconnects_immediately(self):
+        args = _args("binary")
+        args.ws_reconnect_grace = 0.0
+        session = WebSocketSession(args)
+        session._loop = asyncio.get_running_loop()
+        session._run_flag = True
+        session._overlay_connected = True
+
+        session._schedule_overlay_disconnect()
+
+        self.assertFalse(session._overlay_connected)
+        self.assertIsNone(session._disconnect_task)
+
     async def test_quick_reconnect_cancels_pending_disconnect(self):
         args = _args("binary")
         args.ws_reconnect_grace = 0.05


### PR DESCRIPTION
### Motivation
- Cover the edge-case where `--ws-reconnect-grace` is set to `0.0` so `_schedule_overlay_disconnect()` immediately disconnects instead of scheduling a delayed task.

### Description
- Add `test_zero_grace_disconnects_immediately` to `tests/unit/test_ws_payload_mode.py` which sets `args.ws_reconnect_grace = 0.0`, initializes a `WebSocketSession`, sets `session._loop` and `session._run_flag = True`, marks `session._overlay_connected = True`, calls `_schedule_overlay_disconnect()`, and asserts that `session._overlay_connected` becomes `False` and `session._disconnect_task` is `None`.
- Ensure the test explicitly sets `session._run_flag = True` to match the session preconditions required by the disconnect logic.

### Testing
- Ran `pytest -q tests/unit/test_ws_payload_mode.py::WebSocketReconnectGraceTests` and the test suite for that class passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5377924688322880b02fbb535d5e2)