### PR TITLE
Document `--remote-servers` mux option and add reverse service publishing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,24 @@ The tables below are generated from the current parser registrations in `bridge.
 | Option(s) | Default | Description |
 |---|---:|---|
 | `--own-servers` | `None` | Space-separated service specs (client mode only): 'proto,listen_port,listen_bind,proto,host,port' (quoted). Listener instances ignore --own-servers because multiple overlay peers make the target ambiguous. Example: "tcp,80,0.0.0.0,tcp,127.0.0.1,88 udp,16666,::,udp,127.0.0.1,16666" |
+| `--remote-servers` | `None` | Space-separated service specs with the same format as `--own-servers`, but applied to the connected overlay peer via mux control signaling (reverse behavior of `--own-servers`). Example: "udp,16666,0.0.0.0,udp,127.0.0.1,16666 tcp,3128,0.0.0.0,tcp,127.0.0.1,3128". |
 | `--mux-tcp-bp-threshold` | `1` | Mux TCP: size threshold (bytes) to trigger drain() (default 1). |
 | `--mux-tcp-bp-latency-ms` | `300` | Mux TCP: if > 0, drain writers after this ms when bytes pending. |
 | `--mux-tcp-bp-poll-interval-ms` | `50` | Mux TCP: polling interval for time-based backpressure (ms). |
+
+#### Reverse service publishing with `--remote-servers`
+
+`--remote-servers` lets one peer ask the connected peer to expose listeners and bridge them to peer-local targets.
+
+```bash
+--remote-servers "udp,16666,0.0.0.0,udp,127.0.0.1,16666 tcp,3128,0.0.0.0,tcp,127.0.0.1,3128"
+```
+
+Expected behavior:
+
+- On connected peer: bind UDP listener on `0.0.0.0:16666`, and connect forwarded UDP channel to `127.0.0.1:16666`.
+- On connected peer: bind TCP listener on `0.0.0.0:3128`, and connect forwarded TCP channel to `127.0.0.1:3128`.
+- Initiating peer sends a dedicated mux control command after overlay connection so the remote side can install or refresh the requested service catalog.
 
 ### Admin web
 | Option(s) | Default | Description |


### PR DESCRIPTION
### Motivation

- Add documentation for a new channel-mux feature that allows one peer to request the connected peer to expose and forward services. 
- Provide usage example and describe the expected behavior so users can configure reverse service publishing with `--remote-servers`.

### Description

- Add a new `--remote-servers` entry to the Channel mux options table with format and example usage. 
- Introduce a `Reverse service publishing with --remote-servers` subsection that includes a usage snippet and an explanation of the behavior on each peer. 
- Describe the expected runtime behavior: bind listeners on the connected peer and forward channels to peer-local targets, and note that a dedicated mux control command is sent after overlay connection to install or refresh the catalog.

### Testing

- No automated tests were added for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54406c12c83228008e4791fee29cd)