### PR TITLE
Show overlay session listen endpoint in peers table and UI

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -170,13 +170,14 @@ function renderPeerTable(rows) {
   const tbody = document.getElementById('peerConnectionsBody');
   if (!tbody) return;
   if (!rows || rows.length === 0) {
-    tbody.innerHTML = '<tr class="empty-row"><td colspan="15">No peer sessions</td></tr>';
+    tbody.innerHTML = '<tr class="empty-row"><td colspan="16">No peer sessions</td></tr>';
     return;
   }
   tbody.innerHTML = rows.map((row) => `
     <tr>
       <td class="mono">${fmtInteger(row.id)}</td>
       <td class="mono">${row.transport || 'n/a'}</td>
+      <td class="mono">${row.listen || 'n/a'}</td>
       <td><span class="${(row.connected ? 'role-pill role-server' : 'role-pill role-unknown')}">${row.connected ? 'yes' : 'no'}</span></td>
       <td class="mono">${row.peer || 'n/a'}</td>
       <td class="mono">${fmtNumber(row.rtt_est_ms)}</td>

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -109,6 +109,7 @@
                     <tr>
                       <th>ID</th>
                       <th>Transport</th>
+                      <th>Listen</th>
                       <th>Connected</th>
                       <th>Peer</th>
                       <th>RTT Est (ms)</th>
@@ -125,7 +126,7 @@
                     </tr>
                   </thead>
                   <tbody id="peerConnectionsBody">
-                    <tr class="empty-row"><td colspan="15">No peer sessions</td></tr>
+                    <tr class="empty-row"><td colspan="16">No peer sessions</td></tr>
                   </tbody>
                 </table>
               </div>

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -8052,11 +8052,30 @@ class Runner:
             "confirmed_total": int(hist.get("confirmed_total", 0)),
         }
 
+    def _overlay_listen_label(self, transport: str, session: ISession) -> Optional[str]:
+        t = str(transport or "myudp").strip().lower()
+        bind_attr, _, _, listen_port_attr = _overlay_cli_attrs(t)
+        source_args = getattr(session, "_args", None) or self.args
+        bind_host = str(getattr(source_args, bind_attr, "") or "")
+        raw_port = getattr(source_args, listen_port_attr, None)
+        if raw_port is None:
+            return None
+        with contextlib.suppress(Exception):
+            listen_port = int(raw_port)
+            if listen_port <= 0:
+                return None
+            host = bind_host or "0.0.0.0"
+            if ":" in host and not host.startswith("["):
+                host = f"[{host}]"
+            return f"{host}:{listen_port}"
+        return None
+
     def get_peer_connections_snapshot(self) -> dict:
         peers: list = []
         for idx, session in enumerate(self._sessions):
             mux = self._muxes[idx] if idx < len(self._muxes) else None
             label = self._session_labels[idx] if idx < len(self._session_labels) else f"session-{idx}"
+            listen_endpoint = self._overlay_listen_label(label, session)
             m = session.get_metrics()
             udp_rows: list = []
             tcp_rows: list = []
@@ -8098,6 +8117,7 @@ class Runner:
                         "id": f"{idx}:{p.get('peer_id', 0)}",
                         "transport": label,
                         "connected": bool(p.get("connected", session.is_connected())),
+                        "listen": listen_endpoint,
                         "peer": p.get("peer"),
                         "rtt_est_ms": p.get("rtt_est_ms", m.rtt_est_ms),
                         "inflight": m.inflight,
@@ -8141,6 +8161,7 @@ class Runner:
                 "id": idx,
                 "transport": label,
                 "connected": bool(session.is_connected()),
+                "listen": listen_endpoint,
                 "peer": peer_label,
                 "rtt_est_ms": m.rtt_est_ms,
                 "inflight": m.inflight,


### PR DESCRIPTION
### Motivation
- Surface the configured listen endpoint for each overlay session so operators can see which local address/port a transport is bound to for debugging and monitoring.

### Description
- Add `_overlay_listen_label` in `src/obstacle_bridge/bridge.py` to compute a `host:port` listen label from session or runner args, handling IPv6 brackets and missing values.
- Include a `"listen"` field in the objects returned by `get_peer_connections_snapshot` for both overlay peer entries and plain session entries using the new helper.
- Add a `Listen` column to the peers table in `admin_web/index.html` and update the empty-row `colspan` from `15` to `16`.
- Render the new `listen` cell in `admin_web/app.js` `renderPeerTable` so the UI shows the computed endpoint.

### Testing
- Ran the backend test suite including bridge-related tests; tests passed.
- Performed a frontend build and smoke checks confirming the peers table renders the new `Listen` column and the empty state shows `colspan="16"` correctly.
- Linting and formatting checks were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63b7a697883229be56f89469d8f64)