### PR TITLE
Add listener-aware connection snapshots and admin UI State column

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -7,6 +7,10 @@ function fmtInteger(value) {
   if (value == null || Number.isNaN(value)) return 'n/a';
   return String(value);
 }
+function fmtChan(value) {
+  if (value == null || Number.isNaN(value)) return '-';
+  return String(value);
+}
 
 function fmtBytes(value) {
   if (value == null || Number.isNaN(value)) return 'n/a';
@@ -69,7 +73,7 @@ function renderConnectionTable(tbodyId, rows) {
   if (!tbody) return;
 
   if (!rows || rows.length === 0) {
-    tbody.innerHTML = `<tr class="empty-row"><td colspan="10">No ${tbodyId.startsWith('udp') ? 'UDP' : 'TCP'} connections</td></tr>`;
+    tbody.innerHTML = `<tr class="empty-row"><td colspan="11">No ${tbodyId.startsWith('udp') ? 'UDP' : 'TCP'} connections</td></tr>`;
     return;
   }
 
@@ -78,12 +82,15 @@ function renderConnectionTable(tbodyId, rows) {
     const txBytes = row.stats?.tx_bytes ?? 0;
     const rxMsgs = row.stats?.rx_msgs ?? 0;
     const txMsgs = row.stats?.tx_msgs ?? 0;
+    const state = String(row.state || 'connected').toLowerCase();
+    const isListening = state === 'listening';
     return `
       <tr>
-        <td class="mono">${fmtInteger(row.chan_id)}</td>
+        <td class="mono">${fmtChan(row.chan_id)}</td>
         <td class="mono">${fmtInteger(row.svc_id)}</td>
+        <td><span class="${isListening ? 'role-pill role-unknown' : 'role-pill role-client'}">${state}</span></td>
         <td><span class="${roleClass(row.role)}">${row.role || 'unknown'}</span></td>
-        <td class="mono">${fmtEndpoint(row.source)}</td>
+        <td class="mono">${isListening ? 'n/a' : fmtEndpoint(row.source)}</td>
         <td class="mono">${fmtInteger(row.local_port)}</td>
         <td class="mono">${fmtDestination(row.remote_destination)}</td>
         <td class="mono">${fmtBytes(rxBytes)}</td>
@@ -204,6 +211,8 @@ async function loadConnections() {
     renderConnectionTable('tcpConnectionsBody', j.tcp || []);
     setText('udpOpen', fmtInteger(j.counts?.udp ?? (j.udp || []).length));
     setText('tcpOpen', fmtInteger(j.counts?.tcp ?? (j.tcp || []).length));
+    setText('udpListening', fmtInteger(j.counts?.udp_listening ?? 0));
+    setText('tcpListening', fmtInteger(j.counts?.tcp_listening ?? 0));
   } catch (e) {
     console.error('connections load failed', e);
   }

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -136,7 +136,7 @@
             <div class="section-header">
               <div>
                 <h2>UDP Connections</h2>
-                <p>Current UDP mappings and client transports</p>
+                <p>Current UDP mappings and client transports · Listening: <strong id="udpListening">0</strong></p>
               </div>
             </div>
             <div class="table-card card">
@@ -146,6 +146,7 @@
                     <tr>
                       <th>Chan</th>
                       <th>Svc</th>
+                      <th>State</th>
                       <th>Role</th>
                       <th>Source</th>
                       <th>Local Port</th>
@@ -158,7 +159,7 @@
                   </thead>
                   <tbody id="udpConnectionsBody">
                     <tr class="empty-row">
-                      <td colspan="10">No UDP connections</td>
+                      <td colspan="11">No UDP connections</td>
                     </tr>
                   </tbody>
                 </table>
@@ -170,7 +171,7 @@
             <div class="section-header">
               <div>
                 <h2>TCP Connections</h2>
-                <p>Current TCP mappings and active streams</p>
+                <p>Current TCP mappings and active streams · Listening: <strong id="tcpListening">0</strong></p>
               </div>
             </div>
             <div class="table-card card">
@@ -180,6 +181,7 @@
                     <tr>
                       <th>Chan</th>
                       <th>Svc</th>
+                      <th>State</th>
                       <th>Role</th>
                       <th>Source</th>
                       <th>Local Port</th>
@@ -192,7 +194,7 @@
                   </thead>
                   <tbody id="tcpConnectionsBody">
                     <tr class="empty-row">
-                      <td colspan="10">No TCP connections</td>
+                      <td colspan="11">No TCP connections</td>
                     </tr>
                   </tbody>
                 </table>

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -7017,6 +7017,7 @@ class ChannelMux:
             rows.append({
                 "protocol": "udp",
                 "role": "server",
+                "state": "connected",
                 "chan_id": int(chan),
                 "svc_id": int(svc_id),
                 "source": src_ep,
@@ -7026,6 +7027,35 @@ class ChannelMux:
                     {"host": spec.r_host, "port": int(spec.r_port)} if spec else None
                 ),
                 "stats": stats,
+            })
+
+        # UDP listeners: bound sockets waiting for first client/channel mapping.
+        for svc_key, srv_tr in list(self._svc_udp_servers.items()):
+            try:
+                svc_id = int(svc_key[2])
+            except Exception:
+                continue
+            spec = self._svc_spec_or_none(svc_id)
+            sockname = srv_tr.get_extra_info("sockname") if srv_tr else None
+            local_ep = (sockname[0], int(sockname[1])) if isinstance(sockname, tuple) and len(sockname) >= 2 else None
+            rows.append({
+                "protocol": "udp",
+                "role": "server",
+                "state": "listening",
+                "chan_id": None,
+                "svc_id": svc_id,
+                "source": None,
+                "local": local_ep,
+                "local_port": int(local_ep[1]) if local_ep else (int(spec.l_port) if spec else None),
+                "remote_destination": (
+                    {"host": spec.r_host, "port": int(spec.r_port)} if spec else None
+                ),
+                "stats": {
+                    "rx_msgs": 0,
+                    "tx_msgs": 0,
+                    "rx_bytes": 0,
+                    "tx_bytes": 0,
+                },
             })
 
         # Client-side UDP transports: locally created connected UDP socket to remote destination
@@ -7042,6 +7072,7 @@ class ChannelMux:
                 rows.append({
                     "protocol": "udp",
                     "role": "client",
+                    "state": "connected",
                     "chan_id": int(chan),
                     "svc_id": int(svc_id) if svc_id is not None else None,
                     "source": local_ep,
@@ -7056,7 +7087,14 @@ class ChannelMux:
             except Exception:
                 continue
 
-        rows.sort(key=lambda x: (x["protocol"], x["role"], x["chan_id"]))
+        rows.sort(
+            key=lambda x: (
+                x["protocol"],
+                x["role"],
+                str(x.get("state") or ""),
+                -1 if x["chan_id"] is None else int(x["chan_id"]),
+            )
+        )
         return rows
 
     def snapshot_tcp_connections(self) -> list[dict]:
@@ -7090,6 +7128,7 @@ class ChannelMux:
             rows.append({
                 "protocol": "tcp",
                 "role": role,
+                "state": "connected",
                 "chan_id": int(chan),
                 "svc_id": int(svc_id),
                 "source": source,
@@ -7165,6 +7204,7 @@ class ChannelMux:
             rows.append({
                 "protocol": "udp",
                 "role": "server",
+                "state": "connected",
                 "chan_id": int(chan),
                 "svc_id": int(svc_id),
                 "source": src_ep,
@@ -7174,6 +7214,35 @@ class ChannelMux:
                     {"host": spec.r_host, "port": int(spec.r_port)} if spec else None
                 ),
                 "stats": stats,
+            })
+
+        # UDP listeners: bound sockets waiting for first client/channel mapping.
+        for svc_key, srv_tr in list(self._svc_udp_servers.items()):
+            try:
+                svc_id = int(svc_key[2])
+            except Exception:
+                continue
+            spec = self._svc_spec_or_none(svc_id)
+            sockname = srv_tr.get_extra_info("sockname") if srv_tr else None
+            local_ep = (sockname[0], int(sockname[1])) if isinstance(sockname, tuple) and len(sockname) >= 2 else None
+            rows.append({
+                "protocol": "udp",
+                "role": "server",
+                "state": "listening",
+                "chan_id": None,
+                "svc_id": svc_id,
+                "source": None,
+                "local": local_ep,
+                "local_port": int(local_ep[1]) if local_ep else (int(spec.l_port) if spec else None),
+                "remote_destination": (
+                    {"host": spec.r_host, "port": int(spec.r_port)} if spec else None
+                ),
+                "stats": {
+                    "rx_msgs": 0,
+                    "tx_msgs": 0,
+                    "rx_bytes": 0,
+                    "tx_bytes": 0,
+                },
             })
 
         # Client-side UDP transports: locally created connected UDP socket to remote destination
@@ -7190,6 +7259,7 @@ class ChannelMux:
                 rows.append({
                     "protocol": "udp",
                     "role": "client",
+                    "state": "connected",
                     "chan_id": int(chan),
                     "svc_id": int(svc_id) if svc_id is not None else None,
                     "source": local_ep,
@@ -7204,7 +7274,14 @@ class ChannelMux:
             except Exception:
                 continue
 
-        rows.sort(key=lambda x: (x["protocol"], x["role"], x["chan_id"]))
+        rows.sort(
+            key=lambda x: (
+                x["protocol"],
+                x["role"],
+                str(x.get("state") or ""),
+                -1 if x["chan_id"] is None else int(x["chan_id"]),
+            )
+        )
         return rows
 
     def snapshot_tcp_connections(self) -> list[dict]:
@@ -7238,6 +7315,7 @@ class ChannelMux:
             rows.append({
                 "protocol": "tcp",
                 "role": role,
+                "state": "connected",
                 "chan_id": int(chan),
                 "svc_id": int(svc_id),
                 "source": source,
@@ -7247,18 +7325,65 @@ class ChannelMux:
                 "stats": stats,
             })
 
-        rows.sort(key=lambda x: (x["protocol"], x["role"], x["chan_id"]))
+        # TCP listeners: bound server sockets waiting for incoming channels.
+        for svc_key, srv in list(self._svc_tcp_servers.items()):
+            try:
+                svc_id = int(svc_key[2])
+            except Exception:
+                continue
+            spec = self._svc_spec_or_none(svc_id)
+            sockets = list((getattr(srv, "sockets", None) or []))
+            if not sockets:
+                sockets = [None]
+            for sock in sockets:
+                try:
+                    sockname = sock.getsockname() if sock is not None else None
+                except Exception:
+                    sockname = None
+                local_ep = (sockname[0], int(sockname[1])) if isinstance(sockname, tuple) and len(sockname) >= 2 else None
+                rows.append({
+                    "protocol": "tcp",
+                    "role": "server",
+                    "state": "listening",
+                    "chan_id": None,
+                    "svc_id": svc_id,
+                    "source": None,
+                    "local": local_ep,
+                    "local_port": int(local_ep[1]) if local_ep else (int(spec.l_port) if spec else None),
+                    "remote_destination": (
+                        {"host": spec.r_host, "port": int(spec.r_port)} if spec else None
+                    ),
+                    "stats": {
+                        "rx_msgs": 0,
+                        "tx_msgs": 0,
+                        "rx_bytes": 0,
+                        "tx_bytes": 0,
+                    },
+                })
+
+        rows.sort(
+            key=lambda x: (
+                x["protocol"],
+                x["role"],
+                str(x.get("state") or ""),
+                -1 if x["chan_id"] is None else int(x["chan_id"]),
+            )
+        )
         return rows
 
     def snapshot_connections(self) -> dict:
         udp_rows = self.snapshot_udp_connections()
         tcp_rows = self.snapshot_tcp_connections()
+        udp_listening = sum(1 for row in udp_rows if str(row.get("state", "connected")).lower() == "listening")
+        tcp_listening = sum(1 for row in tcp_rows if str(row.get("state", "connected")).lower() == "listening")
         return {
             "udp": udp_rows,
             "tcp": tcp_rows,
             "counts": {
-                "udp": len(udp_rows),
-                "tcp": len(tcp_rows),
+                "udp": len(udp_rows) - udp_listening,
+                "tcp": len(tcp_rows) - tcp_listening,
+                "udp_listening": udp_listening,
+                "tcp_listening": tcp_listening,
             },
         }
 
@@ -7726,16 +7851,23 @@ class RunnerMuxAggregate:
     def snapshot_connections(self) -> dict:
         udp_rows: list[dict] = []
         tcp_rows: list[dict] = []
+        udp_listening = 0
+        tcp_listening = 0
         for mux in self._muxes:
             snap = mux.snapshot_connections()
             udp_rows.extend(snap.get("udp", []))
             tcp_rows.extend(snap.get("tcp", []))
+            counts = snap.get("counts", {}) or {}
+            udp_listening += int(counts.get("udp_listening", 0) or 0)
+            tcp_listening += int(counts.get("tcp_listening", 0) or 0)
         return {
             "udp": udp_rows,
             "tcp": tcp_rows,
             "counts": {
-                "udp": len(udp_rows),
-                "tcp": len(tcp_rows),
+                "udp": len(udp_rows) - udp_listening,
+                "tcp": len(tcp_rows) - tcp_listening,
+                "udp_listening": udp_listening,
+                "tcp_listening": tcp_listening,
             },
         }
 
@@ -7961,7 +8093,11 @@ class Runner:
 
     def get_connections_snapshot(self) -> dict:
         if self.mux is None:
-            return {"udp": [], "tcp": [], "counts": {"udp": 0, "tcp": 0}}
+            return {
+                "udp": [],
+                "tcp": [],
+                "counts": {"udp": 0, "tcp": 0, "udp_listening": 0, "tcp_listening": 0},
+            }
         return self.mux.snapshot_connections()
 
     def get_config_snapshot(self) -> dict:
@@ -8079,6 +8215,10 @@ class Runner:
                     tcp_open = 0
                     for row in udp_rows:
                         chan_id = row.get("chan_id")
+                        if chan_id is None:
+                            continue
+                        if str(row.get("state", "connected")).lower() == "listening":
+                            continue
                         if mux_chans and chan_id not in mux_chans:
                             continue
                         st = row.get("stats", {})
@@ -8087,6 +8227,10 @@ class Runner:
                         udp_open += 1
                     for row in tcp_rows:
                         chan_id = row.get("chan_id")
+                        if chan_id is None:
+                            continue
+                        if str(row.get("state", "connected")).lower() == "listening":
+                            continue
                         if mux_chans and chan_id not in mux_chans:
                             continue
                         st = row.get("stats", {})

--- a/tests/unit/test_connection_snapshots.py
+++ b/tests/unit/test_connection_snapshots.py
@@ -1,0 +1,181 @@
+import argparse
+import asyncio
+import unittest
+
+from obstacle_bridge.bridge import ChannelMux, Runner, SessionMetrics
+
+
+class _FakeSession:
+    def is_connected(self):
+        return False
+
+    def set_on_app_payload(self, _cb):
+        pass
+
+    def set_on_peer_disconnect(self, _cb):
+        pass
+
+
+class _FakeDatagramTransport:
+    def __init__(self, sockname, peername=None):
+        self._sockname = sockname
+        self._peername = peername
+
+    def get_extra_info(self, key):
+        if key == "sockname":
+            return self._sockname
+        if key == "peername":
+            return self._peername
+        return None
+
+
+class _FakeSocket:
+    def __init__(self, sockname):
+        self._sockname = sockname
+
+    def getsockname(self):
+        return self._sockname
+
+
+class _FakeTcpServer:
+    def __init__(self, sockets):
+        self.sockets = sockets
+
+
+class _FakeWriterTransport:
+    def __init__(self, sockname, peername):
+        self._sockname = sockname
+        self._peername = peername
+
+    def get_extra_info(self, key):
+        if key == "sockname":
+            return self._sockname
+        if key == "peername":
+            return self._peername
+        return None
+
+
+class _FakeWriter:
+    def __init__(self, sockname, peername):
+        self.transport = _FakeWriterTransport(sockname, peername)
+
+
+class ChannelMuxSnapshotTests(unittest.TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        self.mux = ChannelMux(_FakeSession(), self.loop)
+        self.udp_spec = ChannelMux.ServiceSpec(1, "udp", "0.0.0.0", 1111, "udp", "192.0.2.10", 9991)
+        self.tcp_spec = ChannelMux.ServiceSpec(2, "tcp", "0.0.0.0", 2222, "tcp", "192.0.2.20", 9992)
+        self.udp_key = ("local", 0, 1)
+        self.tcp_key = ("local", 0, 2)
+        self.mux._local_services[self.udp_key] = self.udp_spec
+        self.mux._local_services[self.tcp_key] = self.tcp_spec
+
+    def tearDown(self):
+        self.loop.close()
+
+    def test_snapshot_counts_listeners_when_no_clients_connected(self):
+        self.mux._svc_udp_servers[self.udp_key] = _FakeDatagramTransport(("0.0.0.0", 1111))
+        self.mux._svc_tcp_servers[self.tcp_key] = _FakeTcpServer([_FakeSocket(("0.0.0.0", 2222))])
+
+        snap = self.mux.snapshot_connections()
+
+        self.assertEqual(snap["counts"]["udp"], 0)
+        self.assertEqual(snap["counts"]["tcp"], 0)
+        self.assertEqual(snap["counts"]["udp_listening"], 1)
+        self.assertEqual(snap["counts"]["tcp_listening"], 1)
+
+        udp_listener = [row for row in snap["udp"] if row.get("state") == "listening"]
+        tcp_listener = [row for row in snap["tcp"] if row.get("state") == "listening"]
+        self.assertEqual(len(udp_listener), 1)
+        self.assertEqual(len(tcp_listener), 1)
+        self.assertIsNone(udp_listener[0]["chan_id"])
+        self.assertIsNone(tcp_listener[0]["chan_id"])
+
+    def test_snapshot_mixed_listeners_and_active_connections(self):
+        self.mux._svc_udp_servers[self.udp_key] = _FakeDatagramTransport(("0.0.0.0", 1111))
+        self.mux._svc_tcp_servers[self.tcp_key] = _FakeTcpServer([_FakeSocket(("0.0.0.0", 2222))])
+
+        self.mux._udp_by_chan[101] = (self.udp_key, ("10.10.10.10", 40001))
+        self.mux._tcp_by_chan[201] = (2, _FakeWriter(("0.0.0.0", 2222), ("10.10.10.20", 40002)))
+        self.mux._tcp_role_by_chan[201] = "server"
+
+        snap = self.mux.snapshot_connections()
+
+        self.assertEqual(snap["counts"]["udp"], 1)
+        self.assertEqual(snap["counts"]["tcp"], 1)
+        self.assertEqual(snap["counts"]["udp_listening"], 1)
+        self.assertEqual(snap["counts"]["tcp_listening"], 1)
+        self.assertIn("connected", {row.get("state") for row in snap["udp"]})
+        self.assertIn("connected", {row.get("state") for row in snap["tcp"]})
+
+
+class _PeerSession:
+    def __init__(self):
+        self._metrics = SessionMetrics()
+
+    def get_metrics(self):
+        return self._metrics
+
+    def is_connected(self):
+        return True
+
+    def get_overlay_peers_snapshot(self):
+        return [
+            {
+                "peer_id": 7,
+                "connected": True,
+                "peer": "198.51.100.7:4433",
+                "mux_chans": [101],
+            }
+        ]
+
+
+class _MuxWithListeners:
+    def snapshot_connections(self):
+        return {
+            "udp": [
+                {
+                    "protocol": "udp",
+                    "state": "listening",
+                    "chan_id": None,
+                    "stats": {"rx_bytes": 0, "tx_bytes": 0},
+                },
+                {
+                    "protocol": "udp",
+                    "state": "connected",
+                    "chan_id": 101,
+                    "stats": {"rx_bytes": 1234, "tx_bytes": 4321},
+                },
+            ],
+            "tcp": [
+                {
+                    "protocol": "tcp",
+                    "state": "listening",
+                    "chan_id": None,
+                    "stats": {"rx_bytes": 0, "tx_bytes": 0},
+                }
+            ],
+            "counts": {"udp": 1, "tcp": 0, "udp_listening": 1, "tcp_listening": 1},
+        }
+
+
+class RunnerPeerSnapshotTests(unittest.TestCase):
+    def test_peer_open_connections_excludes_idle_listeners(self):
+        args = argparse.Namespace(no_dashboard=True, overlay_transport="myudp")
+        runner = Runner(args)
+        runner._sessions = [_PeerSession()]
+        runner._muxes = [_MuxWithListeners()]
+        runner._session_labels = ["myudp"]
+
+        out = runner.get_peer_connections_snapshot()
+        self.assertEqual(len(out["peers"]), 1)
+        peer = out["peers"][0]
+        self.assertEqual(peer["open_connections"]["udp"], 1)
+        self.assertEqual(peer["open_connections"]["tcp"], 0)
+        self.assertEqual(peer["traffic"]["rx_bytes"], 1234)
+        self.assertEqual(peer["traffic"]["tx_bytes"], 4321)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make connection snapshots reflect bound listener sockets even when no channel exists yet so operators can see idle listeners separately from active connections.
- Ensure per-peer aggregates and UI counts are not inflated by idle listeners by exposing explicit listener counts and excluding them from open-connection totals.

### Description
- Extend `ChannelMux.snapshot_udp_connections()` and `ChannelMux.snapshot_tcp_connections()` to append synthetic listener rows with `state: "listening"`, `chan_id: None`, `svc_id` from the service key, `local_port` from the transport/socket, `source: None`, `remote_destination` from the service spec when available, and zeroed `stats`.
- Add `state: "connected"` to active rows and adjust sorting to keep listening rows grouped predictably by `state` and `chan_id`.
- Update `snapshot_connections()` to expose separate counts `counts.udp_listening` and `counts.tcp_listening` and to subtract listener rows from the `udp`/`tcp` active counts returned to callers.
- Propagate listener counts through `RunnerMuxAggregate.snapshot_connections()` and the Runner no-mux fallback shape so aggregated views include `udp_listening`/`tcp_listening`.
- Change `Runner.get_peer_connections_snapshot()` to skip listener rows (or `chan_id is None`) when computing per-peer `open_connections` and traffic so peer aggregates only include mapped/active channels.
- Update admin UI: `admin_web/app.js` adds a `State` column, `fmtChan()` helper, renders listener rows with placeholders (channel `-`, source `n/a`) and shows listening totals; `admin_web/index.html` adds the `State` header and listening badges/elements.
- Add unit tests `tests/unit/test_connection_snapshots.py` covering listener-only snapshots, mixed listeners+active connections, and peer aggregates not inflated by idle listeners.

### Testing
- Ran `pytest -q tests/unit/test_connection_snapshots.py` and all tests passed (`3 passed`).
- Ran `pytest -q tests/unit/test_channel_mux_listener_mode.py` and all tests passed (`8 passed`).
- Verified the new snapshot shape and admin UI data fields by running the unit test suite above; no manual browser tests were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c652e942508322869cc48800b10e31)