### PR TITLE
Admin web: treat log-file config as free-text and reorder Peer Connections columns

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -188,16 +188,16 @@ function renderPeerTable(rows) {
       <td><span class="${(row.connected ? 'role-pill role-server' : 'role-pill role-unknown')}">${row.connected ? 'yes' : 'no'}</span></td>
       <td class="mono">${row.peer || 'n/a'}</td>
       <td class="mono">${fmtNumber(row.rtt_est_ms)}</td>
-      <td class="mono">${fmtInteger(row.inflight)}</td>
       <td class="mono">${fmtInteger(row.open_connections?.udp ?? 0)}</td>
       <td class="mono">${fmtInteger(row.open_connections?.tcp ?? 0)}</td>
       <td class="mono">${fmtBytes(row.traffic?.rx_bytes ?? 0)}</td>
       <td class="mono">${fmtBytes(row.traffic?.tx_bytes ?? 0)}</td>
+      <td class="mono">${fmtInteger(row.decode_errors ?? 0)}</td>
+      <td class="mono">${fmtInteger(row.inflight)}</td>
+      <td class="mono">${fmtInteger(row.myudp?.confirmed_total)}</td>
       <td class="mono">${fmtInteger(row.myudp?.first_pass)}</td>
       <td class="mono">${fmtInteger(row.myudp?.repeated_once)}</td>
       <td class="mono">${fmtInteger(row.myudp?.repeated_multiple)}</td>
-      <td class="mono">${fmtInteger(row.myudp?.confirmed_total)}</td>
-      <td class="mono">${fmtInteger(row.decode_errors ?? 0)}</td>
     </tr>
   `).join('');
 }
@@ -303,8 +303,9 @@ function renderConfigRows(items, config) {
     const currentRaw = configValueToEditor(current);
     const defaultRaw = configValueToEditor(item.default);
     const isLevelSetting = isLoggingLevelSetting(key, current, item.default);
+    const isLogFileSetting = isLogFileConfigSetting(key);
     const isBooleanSetting = isBooleanConfigSetting(current, item.default);
-    const hasChoices = Array.isArray(item.choices) && item.choices.length > 0;
+    const hasChoices = !isLogFileSetting && Array.isArray(item.choices) && item.choices.length > 0;
     const editorHtml = hasChoices
       ? renderChoiceSelect(key, current, item.choices)
       : (isBooleanSetting
@@ -371,8 +372,17 @@ function renderConfigSections(schema, config) {
 
 const LOG_LEVEL_OPTIONS = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'];
 
+function isLogFileConfigSetting(key) {
+  const normalizedKey = String(key || '').toLowerCase();
+  return normalizedKey === '--log-file'
+    || normalizedKey === 'log_file'
+    || normalizedKey.endsWith('.--log-file')
+    || normalizedKey.endsWith('.log_file');
+}
+
 function isLoggingLevelSetting(key, currentValue, defaultValue) {
   const normalizedKey = String(key || '').toLowerCase();
+  if (isLogFileConfigSetting(normalizedKey)) return false;
   const byName = normalizedKey === 'log'
     || normalizedKey.startsWith('log_')
     || normalizedKey.endsWith('_level');

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -113,16 +113,16 @@
                       <th>Connected</th>
                       <th>Peer</th>
                       <th>RTT Est (ms)</th>
-                      <th>Inflight</th>
                       <th>UDP Open</th>
                       <th>TCP Open</th>
                       <th>RX Bytes</th>
                       <th>TX Bytes</th>
+                      <th>Decode Errors</th>
+                      <th>Inflight</th>
+                      <th>myUDP Confirmed Total</th>
                       <th>myUDP First Pass</th>
                       <th>myUDP Repeated Once</th>
                       <th>myUDP Repeated Multiple</th>
-                      <th>myUDP Confirmed Total</th>
-                      <th>Decode Errors</th>
                     </tr>
                   </thead>
                   <tbody id="peerConnectionsBody">


### PR DESCRIPTION
### Motivation
- Make `--log-file` / `log_file` configuration entries editable as a free-text JSON string instead of being rendered as a dropdown, and reorder the Peer Connections table to the requested column layout for clearer status display.

### Description
- Updated the Peer Connections table header order in `admin_web/index.html` to: `ID, Transport, Listen, Connected, Peer, RTT Est (ms), UDP Open, TCP Open, RX Bytes, TX Bytes, Decode Errors, Inflight, myUDP Confirmed Total, myUDP First Pass, myUDP Repeated Once, myUDP Repeated Multiple`.
- Reordered values emitted by `renderPeerTable` in `admin_web/app.js` to match the new column sequence and moved `decode_errors`, `inflight`, and `myudp.confirmed_total` into their requested positions.
- Added `isLogFileConfigSetting` in `admin_web/app.js` and adjusted `renderConfigRows` and `isLoggingLevelSetting` so keys matching `--log-file` / `log_file` (including dotted variants) are always rendered as a free-text JSON input instead of a select/dropdown.

### Testing
- Ran the automated test suite with `pytest -q`, and all tests passed (`46 passed in 1.21s`).
- No UI screenshot verification was performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6873c57f08322af16d0c6a004116a)