### PR TITLE
Add peer ID column to UDP/TCP connection tables

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -11,6 +11,10 @@ function fmtChan(value) {
   if (value == null || Number.isNaN(value)) return '-';
   return String(value);
 }
+function fmtConnectionId(value) {
+  if (value == null || value === '' || Number.isNaN(value)) return '-';
+  return String(value);
+}
 
 function fmtBytes(value) {
   if (value == null || Number.isNaN(value)) return 'n/a';
@@ -73,7 +77,7 @@ function renderConnectionTable(tbodyId, rows) {
   if (!tbody) return;
 
   if (!rows || rows.length === 0) {
-    tbody.innerHTML = `<tr class="empty-row"><td colspan="11">No ${tbodyId.startsWith('udp') ? 'UDP' : 'TCP'} connections</td></tr>`;
+    tbody.innerHTML = `<tr class="empty-row"><td colspan="12">No ${tbodyId.startsWith('udp') ? 'UDP' : 'TCP'} connections</td></tr>`;
     return;
   }
 
@@ -86,6 +90,7 @@ function renderConnectionTable(tbodyId, rows) {
     const isListening = state === 'listening';
     return `
       <tr>
+        <td class="mono">${fmtConnectionId(row.peer_id)}</td>
         <td class="mono">${fmtChan(row.chan_id)}</td>
         <td class="mono">${fmtInteger(row.svc_id)}</td>
         <td><span class="${isListening ? 'role-pill role-unknown' : 'role-pill role-client'}">${state}</span></td>

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -145,6 +145,7 @@
                 <table class="conn-table">
                   <thead>
                     <tr>
+                      <th>ID</th>
                       <th>Chan</th>
                       <th>Svc</th>
                       <th>State</th>
@@ -160,7 +161,7 @@
                   </thead>
                   <tbody id="udpConnectionsBody">
                     <tr class="empty-row">
-                      <td colspan="11">No UDP connections</td>
+                      <td colspan="12">No UDP connections</td>
                     </tr>
                   </tbody>
                 </table>
@@ -180,6 +181,7 @@
                 <table class="conn-table">
                   <thead>
                     <tr>
+                      <th>ID</th>
                       <th>Chan</th>
                       <th>Svc</th>
                       <th>State</th>
@@ -195,7 +197,7 @@
                   </thead>
                   <tbody id="tcpConnectionsBody">
                     <tr class="empty-row">
-                      <td colspan="11">No TCP connections</td>
+                      <td colspan="12">No TCP connections</td>
                     </tr>
                   </tbody>
                 </table>

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -8092,13 +8092,60 @@ class Runner:
         return self.stats.snapshot_status()
 
     def get_connections_snapshot(self) -> dict:
-        if self.mux is None:
+        if not self._muxes:
             return {
                 "udp": [],
                 "tcp": [],
                 "counts": {"udp": 0, "tcp": 0, "udp_listening": 0, "tcp_listening": 0},
             }
-        return self.mux.snapshot_connections()
+
+        udp_rows: list[dict] = []
+        tcp_rows: list[dict] = []
+        udp_listening = 0
+        tcp_listening = 0
+
+        for idx, mux in enumerate(self._muxes):
+            snap = mux.snapshot_connections()
+            mux_udp_rows = list(snap.get("udp", []))
+            mux_tcp_rows = list(snap.get("tcp", []))
+
+            chan_to_peer_id: dict[int, str] = {}
+            with contextlib.suppress(Exception):
+                session = self._sessions[idx] if idx < len(self._sessions) else None
+                getter = getattr(session, "get_overlay_peers_snapshot", None) if session is not None else None
+                overlay_rows = list(getter() or []) if callable(getter) else []
+                for p in overlay_rows:
+                    peer_label = f"{idx}:{p.get('peer_id', 0)}"
+                    for chan in (p.get("mux_chans") or []):
+                        with contextlib.suppress(Exception):
+                            chan_to_peer_id[int(chan)] = peer_label
+
+            for row in mux_udp_rows:
+                r = dict(row)
+                chan = r.get("chan_id")
+                r["peer_id"] = chan_to_peer_id.get(int(chan), str(idx)) if chan is not None else "-"
+                udp_rows.append(r)
+
+            for row in mux_tcp_rows:
+                r = dict(row)
+                chan = r.get("chan_id")
+                r["peer_id"] = chan_to_peer_id.get(int(chan), str(idx)) if chan is not None else "-"
+                tcp_rows.append(r)
+
+            counts = snap.get("counts", {}) or {}
+            udp_listening += int(counts.get("udp_listening", 0) or 0)
+            tcp_listening += int(counts.get("tcp_listening", 0) or 0)
+
+        return {
+            "udp": udp_rows,
+            "tcp": tcp_rows,
+            "counts": {
+                "udp": len(udp_rows) - udp_listening,
+                "tcp": len(tcp_rows) - tcp_listening,
+                "udp_listening": udp_listening,
+                "tcp_listening": tcp_listening,
+            },
+        }
 
     def get_config_snapshot(self) -> dict:
         blocked = {


### PR DESCRIPTION
### Motivation
- Provide an explicit ID column in the UDP/TCP connections tables so operators can see which overlay peer each open/connected channel belongs to, matching the existing peers table ID format.

### Description
- Inserted a new `ID` header as the first column in both UDP and TCP connection tables and adjusted empty-row `colspan` values to account for the extra column (`admin_web/index.html`).
- Added `fmtConnectionId()` and wired the admin UI table renderer to render `peer_id` as the first cell before `chan_id` and `svc_id` (`admin_web/app.js`).
- Enhanced `Runner.get_connections_snapshot()` to aggregate per-mux rows across multiple muxes and to populate a `peer_id` field for each connection row using per-session overlay peer/channel mappings (producing IDs like `sessionIndex:peerId` when available) (`src/obstacle_bridge/bridge.py`).

### Testing
- Successfully type-checked JavaScript with `node --check admin_web/app.js`.
- Verified Python syntax by running `python -m py_compile src/obstacle_bridge/bridge.py` and `python -m py_compile src/obstacle_bridge/__main__.py`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68a32123c8322a8a19d672c5c65b7)