### PR TITLE
Show mux peer slot ID for listening own-server UDP/TCP ports

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -8134,7 +8134,10 @@ class Runner:
                 else:
                     owner_peer_id = r.get("svc_owner_peer_id")
                     if owner_peer_id is None:
-                        r["peer_id"] = "-"
+                        # Locally owned listening services are still tied to this
+                        # mux/peer slot; once traffic arrives the resulting channel
+                        # will use the same slot-derived peer label fallback.
+                        r["peer_id"] = str(idx)
                     else:
                         with contextlib.suppress(Exception):
                             owner_peer_id = int(owner_peer_id)
@@ -8149,7 +8152,10 @@ class Runner:
                 else:
                     owner_peer_id = r.get("svc_owner_peer_id")
                     if owner_peer_id is None:
-                        r["peer_id"] = "-"
+                        # Locally owned listening services are still tied to this
+                        # mux/peer slot; once traffic arrives the resulting channel
+                        # will use the same slot-derived peer label fallback.
+                        r["peer_id"] = str(idx)
                     else:
                         with contextlib.suppress(Exception):
                             owner_peer_id = int(owner_peer_id)


### PR DESCRIPTION
### Motivation

- Improve user-friendliness of the connections table by showing which mux/peer slot a locally-listening own-server port belongs to instead of `"-"` when no owner-peer is set.
- Ensure the displayed peer identifier matches the fallback attribution used once inbound traffic creates a channel for that listening socket.

### Description

- Replace `"-"` with the mux slot fallback `str(idx)` for listening UDP rows in `Runner.get_connections_snapshot` (file `src/obstacle_bridge/bridge.py`).
- Apply the same change to listening TCP rows for consistency between transports.
- Preserve existing owner-peer and channel-based peer labeling behavior and add inline comments explaining the mux-slot fallback rationale.

### Testing

- Compiled the updated module with `python -m py_compile src/obstacle_bridge/bridge.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c770009ce08322ab8322cdba1d2975)