### PR TITLE
Remove redundant `set_on_app_from_peer_bytes` callback in Runner.start

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -8164,8 +8164,6 @@ class Runner:
             session.set_on_peer_rx(self.stats.on_peer_rx_bytes)
             session.set_on_peer_tx(self.stats.on_peer_tx_bytes)
             session.set_on_peer_set(self.stats.on_peer_set)
-            session.set_on_app_from_peer_bytes(self.stats.on_app_tx_bytes)
-
             mux = ChannelMux.from_args(
                 session,
                 loop,


### PR DESCRIPTION
### Motivation
- Remove a redundant callback registration `session.set_on_app_from_peer_bytes(self.stats.on_app_tx_bytes)` in `Runner.start` to avoid duplicate application transmit accounting and rely on the `ChannelMux` handlers.

### Description
- Deleted the call to `session.set_on_app_from_peer_bytes(self.stats.on_app_tx_bytes)` in `src/obstacle_bridge/bridge.py` inside `Runner.start` so application TX is tracked via the `ChannelMux` `on_local_tx_bytes` binding only.

### Testing
- Ran the project's automated test suite with `pytest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c797434b9c8322a7281f0b858af85a)