### PR TITLE
admin_web: show n/a for myUDP metrics on non-myudp peers

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -185,6 +185,11 @@ function renderPeerTable(rows) {
     tbody.innerHTML = '<tr class="empty-row"><td colspan="16">No peer sessions</td></tr>';
     return;
   }
+  const fmtMyUdpMetric = (row, value) => {
+    const transport = String(row.transport || '').toLowerCase();
+    if (transport !== 'myudp') return 'n/a';
+    return fmtInteger(value);
+  };
   tbody.innerHTML = rows.map((row) => `
     <tr>
       <td class="mono">${fmtInteger(row.id)}</td>
@@ -199,10 +204,10 @@ function renderPeerTable(rows) {
       <td class="mono">${fmtBytes(row.traffic?.tx_bytes ?? 0)}</td>
       <td class="mono">${fmtInteger(row.decode_errors ?? 0)}</td>
       <td class="mono">${fmtInteger(row.inflight)}</td>
-      <td class="mono">${fmtInteger(row.myudp?.confirmed_total)}</td>
-      <td class="mono">${fmtInteger(row.myudp?.first_pass)}</td>
-      <td class="mono">${fmtInteger(row.myudp?.repeated_once)}</td>
-      <td class="mono">${fmtInteger(row.myudp?.repeated_multiple)}</td>
+      <td class="mono">${fmtMyUdpMetric(row, row.myudp?.confirmed_total)}</td>
+      <td class="mono">${fmtMyUdpMetric(row, row.myudp?.first_pass)}</td>
+      <td class="mono">${fmtMyUdpMetric(row, row.myudp?.repeated_once)}</td>
+      <td class="mono">${fmtMyUdpMetric(row, row.myudp?.repeated_multiple)}</td>
     </tr>
   `).join('');
 }


### PR DESCRIPTION
### Motivation
- Ensure the peer connections table does not show misleading numeric zeros for myUDP-specific metrics when a peer's `transport` is not `myudp`, and instead displays `n/a`.

### Description
- Add a helper `fmtMyUdpMetric` in `admin_web/app.js` and update the four myUDP metric columns to return `n/a` for non-`myudp` transports while preserving `fmtInteger(...)` rendering for `myudp` peers.

### Testing
- Ran `pytest -q tests/unit/test_connection_snapshots.py` which succeeded (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca28532aa4832293042b2aa93cf8d3)