### PR TITLE
Gracefully continue with defaults when config file is missing

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -9281,9 +9281,18 @@ class ConfigAwareCLI:
         if boot_args.config:
             config_path = pathlib.Path(boot_args.config)
             if explicit_config_flag or config_path.exists():
-                cfg = self._load_json_config(boot_args.config)
-                self._raw_config = cfg
-                self._apply_config_defaults_from_json(parser, cfg)
+                try:
+                    cfg = self._load_json_config(boot_args.config)
+                except FileNotFoundError:
+                    # Missing config should not prevent startup; continue with
+                    # built-in argparse defaults unless a readable config exists.
+                    sys.stderr.write(
+                        f"Config file not found, continuing with defaults: {config_path}\n"
+                    )
+                    sys.stderr.flush()
+                else:
+                    self._raw_config = cfg
+                    self._apply_config_defaults_from_json(parser, cfg)
 
         # Phase 3: final parse; CLI overrides config/defaults
         args = parser.parse_args(remaining)


### PR DESCRIPTION
### Motivation
- Prevent startup failure when a user supplies `-c/--config` pointing at a non-existent file and instead continue running with builtin argparse defaults.

### Description
- Wrap the `_load_json_config` call in `ConfigAwareCLI.parse_args` with a `try/except FileNotFoundError`, emit a clear `stderr` message, and proceed without applying a JSON config; change made in `src/obstacle_bridge/bridge.py`.

### Testing
- Ran `python3 -m obstacle_bridge -c /tmp/does-not-exist-bridge.cfg --dump-config json-flat >/tmp/ob_dump.json` which exited successfully and printed `Config file not found, continuing with defaults: /tmp/does-not-exist-bridge.cfg`, and the dumped JSON was produced from defaults.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca849af6f88322a0b689ac7ab835d4)