### PR TITLE
Handle empty own/remote server config entries in ChannelMux parsing

### DIFF
--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -5752,7 +5752,10 @@ class ChannelMux:
         import shlex
         if not specs:
             return []
-        flat = " ".join(specs)
+        filtered_specs = [s for s in specs if isinstance(s, str) and s.strip()]
+        if not filtered_specs:
+            return []
+        flat = " ".join(filtered_specs)
         tokens = shlex.split(flat)
         out: list[ChannelMux.ServiceSpec] = []
         sid = 1

--- a/tests/unit/test_channel_mux_listener_mode.py
+++ b/tests/unit/test_channel_mux_listener_mode.py
@@ -99,6 +99,10 @@ class ChannelMuxListenerModeTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, '--remote-servers ports must be integers in 1..65535'):
             ChannelMux._parse_remote_servers(['udp,0,0.0.0.0,udp,127.0.0.1,16666'])
 
+    def test_parse_service_specs_treats_empty_config_entries_as_no_services(self):
+        self.assertEqual(ChannelMux._parse_own_servers([None]), [])
+        self.assertEqual(ChannelMux._parse_remote_servers([None, '  ']), [])
+
 
 class ChannelMuxRemoteCatalogTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):


### PR DESCRIPTION
### Motivation
- Parsing `own_servers`/`remote_servers` that contain `None` or blank strings caused a `TypeError` from `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8536c22c8322a4c188567767ba4b)