### PR TITLE
Update listener-mode tests to use REMOTE_SERVICES_SET_V2

### DIFF
--- a/tests/unit/test_channel_mux_listener_mode.py
+++ b/tests/unit/test_channel_mux_listener_mode.py
@@ -133,14 +133,14 @@ class ChannelMuxRemoteCatalogTests(unittest.IsolatedAsyncioTestCase):
         chan, proto, mtype, payload = send_mux.call_args.args
         self.assertEqual(chan, 0)
         self.assertEqual(proto, ChannelMux.Proto.UDP)
-        self.assertEqual(mtype, ChannelMux.MType.REMOTE_SERVICES_SET_V1)
-        self.assertEqual(self.mux._decode_remote_services_set_v1(payload), [spec])
+        self.assertEqual(mtype, ChannelMux.MType.REMOTE_SERVICES_SET_V2)
+        self.assertEqual(self.mux._decode_remote_services_set_v2(payload)[2], [spec])
 
     async def test_receiver_starts_udp_and_tcp_listeners_from_remote_catalog(self):
         udp_spec = ChannelMux.ServiceSpec(1, 'udp', '127.0.0.1', 10001, 'udp', '127.0.0.1', 20001)
         tcp_spec = ChannelMux.ServiceSpec(2, 'tcp', '127.0.0.1', 10002, 'tcp', '127.0.0.1', 20002)
-        payload = self.mux._encode_remote_services_set_v1([udp_spec, tcp_spec])
-        frame = self.mux._pack_mux(0, ChannelMux.Proto.UDP, 0, ChannelMux.MType.REMOTE_SERVICES_SET_V1, payload)
+        payload = self.mux._encode_remote_services_set_v2([udp_spec, tcp_spec])
+        frame = self.mux._pack_mux(0, ChannelMux.Proto.UDP, 0, ChannelMux.MType.REMOTE_SERVICES_SET_V2, payload)
 
         with patch.object(self.mux, '_start_udp_server_for', new=AsyncMock()) as start_udp, patch.object(self.mux, '_start_tcp_server_for', new=AsyncMock()) as start_tcp:
             ok = self.mux.on_app_payload_from_peer(frame, peer_id=77)


### PR DESCRIPTION
### Motivation
- Tests were failing due to the MUX protocol moving from the legacy REMOTE_SERVICES_SET_V1 control frame to REMOTE_SERVICES_SET_V2, so the listener-mode unit tests need to assert and build v2 frames.

### Description
- Updated `tests/unit/test_channel_mux_listener_mode.py` to assert `ChannelMux.MType.REMOTE_SERVICES_SET_V2`, use `_encode_remote_services_set_v2` for payload construction, and verify the payload via `_decode_remote_services_set_v2`.

### Testing
- Ran the focused unit test suite with `python3 -m pytest -q tests/unit/test_channel_mux_listener_mode.py` and it passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8626e4988322bf2b429734a56285)