### PR TITLE
docs: expand overlay integration testing guide

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -1,3 +1,12 @@
 # Testing docs
 
-See `docs/README_TESTING.md` for the detailed testing notes and harness description.
+Detailed testing notes are in `docs/README_TESTING.md`.
+
+This now includes dedicated sections for:
+- `tests/integration/test_overlay_e2e.py`
+- `tests/integration/test_overlay_e2e_reconnect.py`
+
+For both suites, the doc describes:
+- how to start the suite,
+- available command-line options,
+- and the currently implemented test cases/flows.

--- a/docs/README_TESTING.md
+++ b/docs/README_TESTING.md
@@ -12,7 +12,142 @@
 - `virtual_net.py` – NAT mapping, 300ms overlay delay, overlay RX-first PCAP logging, local app logging with global IPs.
 - `scripts/run_udp_bidir_tests.py` – five scenarios, including two large and one concurrent case.
 
-**Run**
+## Overlay integration suites
+
+The repository also ships two end-to-end overlay harnesses in `tests/integration/`:
+
+- `test_overlay_e2e.py`: single-pass smoke checks across all configured transports and address-family combinations.
+- `test_overlay_e2e_reconnect.py`: smoke + reconnect/state-transition regression flows (and one dedicated two-client WS listener scenario).
+
+Both scripts are **standalone Python runners** (not pytest functions). They start a local bounce-back server, launch one or more `ObstacleBridge.py` processes, wait for tunnel readiness, then probe through the overlay and fail with process/log dumps if a step breaks.
+
+---
+
+## 1) `test_overlay_e2e.py`
+
+### Start the suite
+
+Run all default cases:
+
 ```bash
-python scripts/run_udp_bidir_tests.py
+python tests/integration/test_overlay_e2e.py
 ```
+
+List available case names:
+
+```bash
+python tests/integration/test_overlay_e2e.py --list-cases
+```
+
+Run only selected cases:
+
+```bash
+python tests/integration/test_overlay_e2e.py \
+  --cases case01_udp_over_own_udp_ipv4 case08_overlay_ws_ipv4
+```
+
+Preserve logs in a chosen folder:
+
+```bash
+python tests/integration/test_overlay_e2e.py --log-dir /tmp/overlay-e2e-logs
+```
+
+### Options
+
+- `--cases <case...>`: run only the selected named cases (default: all).
+- `--list-cases`: print supported case names and exit.
+- `--log-dir <dir>`: keep process and bounce logs in a fixed directory (otherwise temp dir).
+- `--settle-seconds <float>`: override default startup wait before probing.
+- `--require-aioquic`: fail immediately if `aioquic` is missing (instead of silently skipping QUIC coverage).
+
+### Implemented tests
+
+Default case set (`DEFAULT_CASES`) currently includes 11 smoke scenarios:
+
+1. `case01_udp_over_own_udp_ipv4`
+2. `case02_udp_over_own_udp_overlay_ipv6_clients_ipv4`
+3. `case03_udp_over_own_udp_overlay_ipv6_clients_ipv6`
+4. `case04_tcp_over_own_udp_clients_ipv4`
+5. `case05_tcp_over_own_udp_clients_ipv6`
+6. `case06_overlay_tcp_ipv4`
+7. `case07_overlay_tcp_ipv6`
+8. `case08_overlay_ws_ipv4`
+9. `case09_overlay_ws_ipv6`
+10. `case10_overlay_quic_ipv4`
+11. `case11_overlay_quic_ipv6`
+
+Each case validates that a probe payload (`0x01 0x30`) traverses the configured bridge path and returns the expected transformed payload (`0x02 0x30`) from the bounce service.
+
+---
+
+## 2) `test_overlay_e2e_reconnect.py`
+
+### Start the suite
+
+Run default smoke mode (all reconnect-harness cases):
+
+```bash
+python tests/integration/test_overlay_e2e_reconnect.py
+```
+
+Run reconnect regression mode:
+
+```bash
+python tests/integration/test_overlay_e2e_reconnect.py --reconnect
+```
+
+Run only one case in reconnect mode with custom transition timeout:
+
+```bash
+python tests/integration/test_overlay_e2e_reconnect.py \
+  --cases case08_overlay_ws_ipv4 \
+  --reconnect \
+  --reconnect-timeout 45
+```
+
+List cases:
+
+```bash
+python tests/integration/test_overlay_e2e_reconnect.py --list-cases
+```
+
+### Options
+
+- `--cases <case...>`: run only selected case names (default: all).
+- `--list-cases`: print supported names and exit.
+- `--log-dir <dir>`: output directory for child-process logs.
+- `--settle-seconds <float>`: override case startup delay.
+- `--require-aioquic`: fail fast if `aioquic` is unavailable.
+- `--reconnect`: switch from smoke probe mode to reconnect transition mode.
+- `--reconnect-timeout <float>`: timeout used for connected/disconnected admin-state waits.
+
+### Implemented tests
+
+Default case set currently includes base transport checks plus localhost-resolution variants:
+
+- Base IPv4 cases:
+  - `case01_udp_over_own_udp_ipv4`
+  - `case06_overlay_tcp_ipv4`
+  - `case08_overlay_ws_ipv4`
+  - `case10_overlay_quic_ipv4`
+  - `case12_overlay_ws_ipv4_listener_two_clients`
+- Localhost + resolve-family variants for UDP/TCP/WS/QUIC:
+  - `*_localhost_ipv4`
+  - `*_localhost_ipv6`
+
+Behavior by mode:
+
+- **Smoke mode (default)**
+  - Runs single pass probe validation for each case.
+  - For `case12_overlay_ws_ipv4_listener_two_clients`, runs the dedicated two-client listener flow and verifies both clients can independently traverse the same WS listener.
+
+- **Reconnect mode (`--reconnect`)**
+  - Runs a staged restart/disconnect/reconnect workflow with admin API checks:
+    1. Verify initial connectivity.
+    2. Restart server and wait for connected state recovery.
+    3. Stop server and verify disconnection + probe failure.
+    4. Restart server and verify recovery.
+    5. Stop client and verify disconnection + probe failure.
+    6. Restart client and verify recovery.
+
+These checks ensure overlay transport resiliency and control-plane state tracking (connected/not connected) for restart events.


### PR DESCRIPTION
### Motivation
- Make it easier to discover and run the repository's overlay integration harnesses by expanding the testing documentation. 
- Surface command-line usage, available cases, and the intended test behavior for both smoke and reconnect flows so contributors can reproduce e2e scenarios. 

### Description
- Update `README_TESTING.md` to point to the expanded `docs/README_TESTING.md` and call out the two integration runners `tests/integration/test_overlay_e2e.py` and `tests/integration/test_overlay_e2e_reconnect.py`. 
- Add a new `docs/README_TESTING.md` section describing how to run `test_overlay_e2e.py` and `test_overlay_e2e_reconnect.py`, including example `python` invocations and `--list-cases` / `--cases` / `--log-dir` / `--settle-seconds` / `--require-aioquic` options and reconnect-specific flags (`--reconnect`, `--reconnect-timeout`). 
- Document the implemented test cases and flows (default `DEFAULT_CASES` lists, probe payload/expected reply semantics, localhost-resolution variants, and the two-client WS listener scenario). 
- Files changed: `README_TESTING.md` and `docs/README_TESTING.md`. 

### Testing
- Ran `python tests/integration/test_overlay_e2e.py --list-cases` which returned the configured smoke-case names and completed successfully. 
- Ran `python tests/integration/test_overlay_e2e_reconnect.py --list-cases` which returned the configured reconnect-case names and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca87e08f60832290bf7fef0ec33740)