### PR TITLE
Add Misc-tab Exit button and non-restart shutdown exit code

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -145,6 +145,14 @@ async function restart() {
   alert(JSON.stringify(j));
 }
 
+async function exitProgram() {
+  const confirmed = window.confirm('Exit the program now?');
+  if (!confirmed) return;
+  const r = await fetch('/api/shutdown', { method: 'POST' });
+  const j = await r.json();
+  alert(JSON.stringify(j));
+}
+
 async function loadStatus() {
   try {
     const r = await fetch('/api/status', { cache: 'no-store' });
@@ -475,6 +483,7 @@ function initMetaToggle() {
 }
 
 document.getElementById('restartBtn').addEventListener('click', restart);
+document.getElementById('exitBtn')?.addEventListener('click', exitProgram);
 document.getElementById('configReloadBtn')?.addEventListener('click', loadConfig);
 document.getElementById('configSaveBtn')?.addEventListener('click', saveConfig);
 document.getElementById('logsReloadBtn')?.addEventListener('click', loadLogs);

--- a/admin_web/index.html
+++ b/admin_web/index.html
@@ -248,6 +248,9 @@
               <button id="toggleMetaBtn" class="btn btn-secondary" type="button">Toggle JSON</button>
             </div>
             <pre id="meta" class="meta-box"></pre>
+            <div class="misc-actions">
+              <button id="exitBtn" class="btn btn-danger" type="button">Exit Program</button>
+            </div>
           </section>
         </section>
       </main>

--- a/admin_web/style.css
+++ b/admin_web/style.css
@@ -565,6 +565,10 @@ h1 {
   padding: 24px 18px;
 }
 
+.misc-actions {
+  margin-top: 16px;
+}
+
 @media (max-width: 1200px) {
   .conn-table {
     min-width: 760px;

--- a/src/obstacle_bridge/bridge.py
+++ b/src/obstacle_bridge/bridge.py
@@ -8137,6 +8137,7 @@ class Runner:
         self.admin_web = None
         self._restart_requested: Optional[asyncio.Event] = None
         self._restart_requested_flag = False
+        self._shutdown_exit_code: Optional[int] = None
         self._last_connected_monotonic: Optional[float] = None
         self._last_disconnected_monotonic: Optional[float] = None
         self._client_restart_watchdog_task: Optional[asyncio.Task] = None        
@@ -8257,6 +8258,10 @@ class Runner:
         if self._restart_requested is not None and self._restart_requested.is_set():
             self.log.warning("[RUNNER] exiting rc=75")
             raise SystemExit(75)
+
+        if self._shutdown_exit_code is not None:
+            self.log.warning("[RUNNER] exiting rc=%d", self._shutdown_exit_code)
+            raise SystemExit(self._shutdown_exit_code)
 
         self.log.debug("[RUNNER] Leaving stop")
 
@@ -8723,8 +8728,12 @@ class Runner:
             setattr(self.args, key, value)
         return self.save_runtime_config()
 
-    def request_shutdown(self) -> None:
-        self.log.debug("[SERVER] Runner shutdown requested")
+    def request_shutdown(self, exit_code: Optional[int] = None) -> None:
+        if exit_code is not None:
+            self._shutdown_exit_code = int(exit_code)
+            self.log.debug("[SERVER] Runner shutdown requested rc=%d", self._shutdown_exit_code)
+        else:
+            self.log.debug("[SERVER] Runner shutdown requested")
         self._stop_requested = True
         if self._stop is not None:
             self._stop.set()
@@ -9144,8 +9153,8 @@ class AdminWebUI:
         self._log_api_response("/api/shutdown", 200, payload)
         await self._send_json(writer, 200, payload)
 
-        # let response flush before stopping
-        asyncio.get_running_loop().call_soon(self.runner.request_shutdown)
+        # let response flush before stopping (non-restart exit code)
+        asyncio.get_running_loop().call_soon(self.runner.request_shutdown, 76)
 
     async def _handle_static(self, writer, req_path):
         base = pathlib.Path(self.args.admin_web_dir).resolve()


### PR DESCRIPTION
### Motivation
- Provide an accessible "Exit" action under the Misc tab (separate from the header Restart button) that terminates the program with an exit code different from the restart code 75.
- Allow the admin shutdown endpoint to request a distinct non-restart exit code so external orchestration can distinguish an intentional shutdown from a restart-request.

### Description
- Added an "Exit Program" button to the admin UI Misc tab and a small `.misc-actions` style block for spacing (`admin_web/index.html`, `admin_web/style.css`).
- Wired the button in the admin UI JavaScript to confirm with the user and `POST /api/shutdown` (`admin_web/app.js`).
- Extended `Runner` to store an optional `_shutdown_exit_code` and updated `request_shutdown` to accept an optional `exit_code` parameter (`src/obstacle_bridge/bridge.py`).
- Updated `run()` to raise `SystemExit` with the configured shutdown exit code when present, and changed the admin `_handle_shutdown` flow to schedule `request_shutdown(76)` so shutdown uses exit code `76` (distinct from restart `75`).

### Testing
- Compiled Python file with `python -m py_compile src/obstacle_bridge/bridge.py` which succeeded.
- Checked JavaScript syntax with `node --check admin_web/app.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca89be44f4832280ef3d693c04408c)