### PR TITLE
Avoid admin web port collisions in integration overlay E2E tests

### DIFF
--- a/tests/integration/test_overlay_e2e.py
+++ b/tests/integration/test_overlay_e2e.py
@@ -398,6 +398,11 @@ def build_commands(case: Case, log_dir: Path) -> List[tuple[str, List[str], Dict
     py = sys.executable
     server_cmd = [py, str(BRIDGE)] + materialize_args(case.bridge_server_args, log_dir, case.name, 'bridge_server')
     client_cmd = [py, str(BRIDGE)] + materialize_args(case.bridge_client_args, log_dir, case.name, 'bridge_client')
+
+    # Avoid collisions with local services when multiple bridge instances are launched.
+    server_cmd += ['--admin-web-port', '0']
+    client_cmd += ['--admin-web-port', '0']
+
     return [
         ('bridge_server', server_cmd, case.server_env),
         ('bridge_client', client_cmd, case.client_env),


### PR DESCRIPTION
### Motivation
- Prevent flaky integration failures caused by bridge subprocesses trying to bind to the fixed admin web port (`127.0.0.1:18080`) when multiple instances run on the same host.

### Description
- In `tests/integration/test_overlay_e2e.py` `build_commands`, append `--admin-web-port 0` to both server and client commandlines so the admin UI binds to an ephemeral port, and add a short comment explaining the change.

### Testing
- Ran `python3 tests/integration/test_overlay_e2e.py --cases case01_udp_over_own_udp_ipv4`, which reproduced the bind error before the change and passes after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8ea5d80083228aa69afd718bf868)