### PR TITLE
Always run reconnect workflow in reconnect E2E harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ ObstacleBridge is a Python-based overlay and channel-multiplexing toolkit for ba
 ## Entry points
 - `python -m obstacle_bridge --help`
 
+## Integration reconnect suite
+- `python tests/integration/test_overlay_e2e_reconnect.py` runs the reconnect regression workflow by default for selected cases.
+- `--reconnect-timeout` can be used to tune connected/disconnected transition waits.
+- Additional test-suite usage details are documented in `docs/README_TESTING.md`.
+
 ## Quick-start examples
 ### 1) WireGuard bridge setup
 This example assumes the bridge **server** can already reach a local WireGuard UDP service on `127.0.0.1:16666`. The **peer** connects to that bridge server and recreates the same UDP port locally on `127.0.0.1:16666`, so a WireGuard client on the peer machine can point at `localhost:16666`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,24 +84,17 @@ Each case validates that a probe payload (`0x01 0x30`) traverses the configured 
 
 ### Start the suite
 
-Run default smoke mode (all reconnect-harness cases):
+Run reconnect regression mode (all reconnect-harness cases):
 
 ```bash
 python tests/integration/test_overlay_e2e_reconnect.py
 ```
 
-Run reconnect regression mode:
-
-```bash
-python tests/integration/test_overlay_e2e_reconnect.py --reconnect
-```
-
-Run only one case in reconnect mode with custom transition timeout:
+Run only one case with custom transition timeout:
 
 ```bash
 python tests/integration/test_overlay_e2e_reconnect.py \
   --cases case08_overlay_ws_ipv4 \
-  --reconnect \
   --reconnect-timeout 45
 ```
 
@@ -118,7 +111,6 @@ python tests/integration/test_overlay_e2e_reconnect.py --list-cases
 - `--log-dir <dir>`: output directory for child-process logs.
 - `--settle-seconds <float>`: override case startup delay.
 - `--require-aioquic`: fail fast if `aioquic` is unavailable.
-- `--reconnect`: switch from smoke probe mode to reconnect transition mode.
 - `--reconnect-timeout <float>`: timeout used for connected/disconnected admin-state waits.
 
 ### Implemented tests
@@ -135,19 +127,14 @@ Default case set currently includes base transport checks plus localhost-resolut
   - `*_localhost_ipv4`
   - `*_localhost_ipv6`
 
-Behavior by mode:
+Behavior:
 
-- **Smoke mode (default)**
-  - Runs single pass probe validation for each case.
-  - For `case12_overlay_ws_ipv4_listener_two_clients`, runs the dedicated two-client listener flow and verifies both clients can independently traverse the same WS listener.
-
-- **Reconnect mode (`--reconnect`)**
-  - Runs a staged restart/disconnect/reconnect workflow with admin API checks:
-    1. Verify initial connectivity.
-    2. Restart server and wait for connected state recovery.
-    3. Stop server and verify disconnection + probe failure.
-    4. Restart server and verify recovery.
-    5. Stop client and verify disconnection + probe failure.
-    6. Restart client and verify recovery.
+- Runs a staged restart/disconnect/reconnect workflow with admin API checks:
+  1. Verify initial connectivity.
+  2. Restart server and wait for connected state recovery.
+  3. Stop server and verify disconnection + probe failure.
+  4. Restart server and verify recovery.
+  5. Stop client and verify disconnection + probe failure.
+  6. Restart client and verify recovery.
 
 These checks ensure overlay transport resiliency and control-plane state tracking (connected/not connected) for restart events.

--- a/docs/README_TESTING.md
+++ b/docs/README_TESTING.md
@@ -84,24 +84,17 @@ Each case validates that a probe payload (`0x01 0x30`) traverses the configured 
 
 ### Start the suite
 
-Run default smoke mode (all reconnect-harness cases):
+Run reconnect regression mode (all reconnect-harness cases):
 
 ```bash
 python tests/integration/test_overlay_e2e_reconnect.py
 ```
 
-Run reconnect regression mode:
-
-```bash
-python tests/integration/test_overlay_e2e_reconnect.py --reconnect
-```
-
-Run only one case in reconnect mode with custom transition timeout:
+Run only one case with custom transition timeout:
 
 ```bash
 python tests/integration/test_overlay_e2e_reconnect.py \
   --cases case08_overlay_ws_ipv4 \
-  --reconnect \
   --reconnect-timeout 45
 ```
 
@@ -118,7 +111,6 @@ python tests/integration/test_overlay_e2e_reconnect.py --list-cases
 - `--log-dir <dir>`: output directory for child-process logs.
 - `--settle-seconds <float>`: override case startup delay.
 - `--require-aioquic`: fail fast if `aioquic` is unavailable.
-- `--reconnect`: switch from smoke probe mode to reconnect transition mode.
 - `--reconnect-timeout <float>`: timeout used for connected/disconnected admin-state waits.
 
 ### Implemented tests
@@ -135,19 +127,14 @@ Default case set currently includes base transport checks plus localhost-resolut
   - `*_localhost_ipv4`
   - `*_localhost_ipv6`
 
-Behavior by mode:
+Behavior:
 
-- **Smoke mode (default)**
-  - Runs single pass probe validation for each case.
-  - For `case12_overlay_ws_ipv4_listener_two_clients`, runs the dedicated two-client listener flow and verifies both clients can independently traverse the same WS listener.
-
-- **Reconnect mode (`--reconnect`)**
-  - Runs a staged restart/disconnect/reconnect workflow with admin API checks:
-    1. Verify initial connectivity.
-    2. Restart server and wait for connected state recovery.
-    3. Stop server and verify disconnection + probe failure.
-    4. Restart server and verify recovery.
-    5. Stop client and verify disconnection + probe failure.
-    6. Restart client and verify recovery.
+- Runs a staged restart/disconnect/reconnect workflow with admin API checks:
+  1. Verify initial connectivity.
+  2. Restart server and wait for connected state recovery.
+  3. Stop server and verify disconnection + probe failure.
+  4. Restart server and verify recovery.
+  5. Stop client and verify disconnection + probe failure.
+  6. Restart client and verify recovery.
 
 These checks ensure overlay transport resiliency and control-plane state tracking (connected/not connected) for restart events.

--- a/tests/integration/test_overlay_e2e_reconnect.py
+++ b/tests/integration/test_overlay_e2e_reconnect.py
@@ -1103,7 +1103,6 @@ def parse_args() -> argparse.Namespace:
     p.add_argument('--log-dir', default=None, help='Directory for child-process logs (default: temp dir)')
     p.add_argument('--settle-seconds', type=float, default=None, help='Override per-case settle time')
     p.add_argument('--require-aioquic', action='store_true', help='Fail fast if aioquic is not importable')
-    p.add_argument('--reconnect', action='store_true', help='Run reconnect regression flow instead of single smoke probe')
     p.add_argument('--reconnect-timeout', type=float, default=30.0, help='Timeout for connected/disconnected state transitions')
     return p.parse_args()
 
@@ -1126,7 +1125,7 @@ def main() -> int:
     log.info(f'Using log dir: {log_dir}')
     log.info(f'ObstacleBridge.py: {BRIDGE}')
     log.info('Bounce-back server: built into this harness')
-    log.info(f'Mode: {"reconnect" if args.reconnect else "smoke"}')
+    log.info('Mode: reconnect')
 
     if args.require_aioquic:
         try:
@@ -1140,12 +1139,7 @@ def main() -> int:
         case = CASES[name]
         log.info(f'=== RUN {case.name} ===')
         try:
-            if args.reconnect:
-                run_case_reconnect(case, log_dir, idx, settle_s=args.settle_seconds, reconnect_timeout=args.reconnect_timeout)
-            elif name == 'case12_overlay_ws_ipv4_listener_two_clients':
-                run_case_two_peer_clients_listener(case, log_dir, idx, settle_s=args.settle_seconds)
-            else:
-                run_case(case, log_dir, idx, settle_s=args.settle_seconds)
+            run_case_reconnect(case, log_dir, idx, settle_s=args.settle_seconds, reconnect_timeout=args.reconnect_timeout)
             log.info(f'PASS {case.name}')
         except Exception as e:
             log.info(f'FAIL {case.name}: {e}')


### PR DESCRIPTION
### Motivation
- Ensure the `test_overlay_e2e_reconnect.py` harness always exercises the reconnect/regression flow instead of offering a smoke-mode toggle.
- Simplify test invocation and reduce accidental smoke-mode runs by removing the CLI switch for mode selection.
- Align documentation with the harness so examples and guides reflect the default reconnect-only behavior.

### Description
- Removed the `--reconnect` CLI argument from `tests/integration/test_overlay_e2e_reconnect.py` and made the harness always call `run_case_reconnect(...)` for selected cases.
- Updated the harness logging to always report `Mode: reconnect`.
- Updated `docs/README.md`, `docs/README_TESTING.md`, and the top-level `README.md` to remove smoke-mode and `--reconnect` usage and document the reconnect-only invocation and `--reconnect-timeout` option.

### Testing
- Ran `python tests/integration/test_overlay_e2e_reconnect.py --help` and confirmed the `--reconnect` option was removed and `--reconnect-timeout` is present (help output succeeded).
- Ran `rg` searches to verify occurrences of `--reconnect` and smoke-mode text were removed from `tests/integration/test_overlay_e2e_reconnect.py`, `docs/README.md`, and `docs/README_TESTING.md` (searches succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9a7cd4fc8322af0026da5a9ddee3)