### PR TITLE
tests: force missing config in overlay e2e harness to avoid local cfg leakage

### DIFF
--- a/tests/integration/test_overlay_e2e.py
+++ b/tests/integration/test_overlay_e2e.py
@@ -396,8 +396,14 @@ def materialize_args(args: List[str], log_dir: Path, case_name: str, side: str) 
 
 def build_commands(case: Case, log_dir: Path) -> List[tuple[str, List[str], Dict[str, str]]]:
     py = sys.executable
+    missing_cfg = str(log_dir / f'{case.name}_missing.cfg')
     server_cmd = [py, str(BRIDGE)] + materialize_args(case.bridge_server_args, log_dir, case.name, 'bridge_server')
     client_cmd = [py, str(BRIDGE)] + materialize_args(case.bridge_client_args, log_dir, case.name, 'bridge_client')
+
+    # Force defaults from the test case/CLI and avoid loading a local ObstacleBridge.cfg.
+    # ConfigAwareCLI treats an explicitly requested missing config as non-fatal.
+    server_cmd += ['--config', missing_cfg]
+    client_cmd += ['--config', missing_cfg]
 
     # Avoid collisions with local services when multiple bridge instances are launched.
     server_cmd += ['--admin-web-port', '0']


### PR DESCRIPTION
### Motivation
- The overlay end-to-end harness could accidentally pick up a developer-local `ObstacleBridge.cfg` and apply its values as defaults, causing test subprocesses to target external hosts and clash on ports. 

### Description
- Updated `tests/integration/test_overlay_e2e.py` to create a per-case missing config path and pass `--config <case>_missing.cfg` to both bridge server and bridge client subprocesses. 
- Added explanatory comments and the `missing_cfg` variable in `build_commands` so the harness forces the CLI to behave as if an explicitly-requested config is missing. 
- Left the existing ephemeral admin port behavior (`--admin-web-port 0`) unchanged.

### Testing
- Reproduced the original failure locally and then ran the modified harness for the WS-focused cases with `python3 tests/integration/test_overlay_e2e.py --cases case08_overlay_ws_ipv4 case09_overlay_ws_ipv6`. 
- Result: `case09_overlay_ws_ipv6` passed and `case08_overlay_ws_ipv4` still intermittently failed due to a separate startup race (client may attempt the WS connect before the server begins listening). 
- No other automated test runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9d9337b083229c57c2d60ef918eb)