### PR TITLE
Add opt-in pytest integration tests for overlay E2E harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,10 @@ where = ["src"]
 
 [project.scripts]
 ObstacleBridge = "obstacle_bridge.bridge:main"
+
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: end-to-end integration tests",
+    "slow: long-running tests",
+]

--- a/tests/integration/test_overlay_e2e.py
+++ b/tests/integration/test_overlay_e2e.py
@@ -12,6 +12,8 @@ import logging
 import time
 import urllib.error
 import urllib.request
+
+import pytest
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -1197,6 +1199,37 @@ def wait_both_connected(
         f'Both not CONNECTED before timeout; '
         f'server_last={last_server!r} client_last={last_client!r}'
     )
+
+
+def _require_overlay_e2e_enabled() -> None:
+    if os.environ.get("RUN_OVERLAY_E2E") != "1":
+        pytest.skip("Set RUN_OVERLAY_E2E=1 to run overlay integration harness")
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("case_name", BASIC_CASES)
+def test_overlay_e2e_basic(case_name: str, tmp_path: Path) -> None:
+    _require_overlay_e2e_enabled()
+    run_case(CASES[case_name], tmp_path, ALL_CASES.index(case_name))
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("case_name", RECONNECT_CASES)
+def test_overlay_e2e_reconnect(case_name: str, tmp_path: Path) -> None:
+    _require_overlay_e2e_enabled()
+    run_case_reconnect(CASES[case_name], tmp_path, ALL_CASES.index(case_name))
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.parametrize("case_name", LISTENER_CASES)
+def test_overlay_e2e_listener_two_clients(case_name: str, tmp_path: Path) -> None:
+    _require_overlay_e2e_enabled()
+    run_case_two_peer_clients_listener(CASES[case_name], tmp_path, ALL_CASES.index(case_name))
+
+
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description='Automated end-to-end overlay tests with built-in bounce-back server')


### PR DESCRIPTION
### Motivation
- Make the heavy end-to-end overlay harness runnable under `pytest` while keeping it opt-in to avoid slowing normal CI runs.
- Provide parametrized pytest entrypoints so individual cases can be selected, filtered, and excluded using pytest marks.
- Avoid unknown-mark warnings by registering the `integration` and `slow` markers in project config.

### Description
- Add `import pytest` and a gating helper `_require_overlay_e2e_enabled()` that skips tests unless `RUN_OVERLAY_E2E=1` is set.
- Add three parametrized pytest tests that reuse the existing harness functions and catalogs: `test_overlay_e2e_basic` (BASIC_CASES -> `run_case`), `test_overlay_e2e_reconnect` (RECONNECT_CASES -> `run_case_reconnect`), and `test_overlay_e2e_listener_two_clients` (LISTENER_CASES -> `run_case_two_peer_clients_listener`).
- Register `integration` and `slow` markers in `pyproject.toml` to avoid `PytestUnknownMarkWarning` and allow marker-based inclusion/exclusion.
- Preserve the existing CLI `main()` and file-level behavior so script usage remains unchanged.

### Testing
- Ran `pytest -q tests/integration/test_overlay_e2e.py --collect-only` which collected 31 tests successfully after adding the markers.
- Confirmed initial unknown-mark warnings were resolved by adding the markers to `pyproject.toml` and re-running collection which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa36d61388322af4571c15c10c119)