### PR TITLE
docs: add pytest-mode guidance for overlay integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ ObstacleBridge is a Python-based overlay and channel-multiplexing toolkit for ba
 
 ## Integration reconnect suite
 - `python tests/integration/test_overlay_e2e.py --mode reconnect` runs the reconnect regression workflow by default for selected cases.
+- `RUN_OVERLAY_E2E=1 pytest -q tests/integration/test_overlay_e2e.py -k reconnect` runs the same reconnect path via pytest.
 - `--reconnect-timeout` can be used to tune connected/disconnected transition waits.
 - Additional test-suite usage details are documented in `docs/README_TESTING.md`.
 

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -9,4 +9,7 @@ This now includes dedicated sections for:
 For both suites, the doc describes:
 - how to start the suite,
 - available command-line options,
+- pytest mode support (including marker filters),
 - and the currently implemented test cases/flows.
+
+- Pytest execution mode is supported; see `docs/README_TESTING.md` for copy/paste commands.

--- a/docs/README_TESTING.md
+++ b/docs/README_TESTING.md
@@ -18,9 +18,42 @@ The repository also ships two end-to-end overlay harnesses in `tests/integration
 
 - `test_overlay_e2e.py`: unified smoke/reconnect/listener harness. Use `--mode basic`, `--mode reconnect`, or `--mode listener-two-clients`.
 
-The script is a **standalone Python runner** (not a pytest function). It starts a local bounce-back server, launches one or more `ObstacleBridge.py` processes, waits for tunnel readiness, then probes through the overlay and fails with process/log dumps if a step breaks.
+The harness supports **two execution modes**:
+
+- **CLI mode** (direct script entrypoint) for explicit `--mode` and `--cases` control.
+- **pytest mode** for marker/k-expression filtering and standard pytest workflows.
+
+Both paths start a local bounce-back server, launch one or more `ObstacleBridge.py` processes, wait for tunnel readiness, then probe through the overlay and fail with process/log dumps if a step breaks.
 
 ---
+
+
+## Pytest interface
+
+Run the unified harness through pytest (environment gate required):
+
+```bash
+RUN_OVERLAY_E2E=1 pytest -q tests/integration/test_overlay_e2e.py -k basic
+RUN_OVERLAY_E2E=1 pytest -q tests/integration/test_overlay_e2e.py -k reconnect
+RUN_OVERLAY_E2E=1 pytest -q tests/integration/test_overlay_e2e.py -k listener_two_clients
+```
+
+### Markers and filtering
+
+The overlay end-to-end coverage uses pytest markers:
+
+- `integration`: integration/subprocess tests (typically slower than unit scope).
+- `slow`: long-running scenarios (restart/reconnect and listener multi-client flows).
+
+Common marker filters:
+
+```bash
+# run integration tests that are not marked slow
+RUN_OVERLAY_E2E=1 pytest -q tests/integration/test_overlay_e2e.py -m "integration and not slow"
+
+# run only slow integration coverage
+RUN_OVERLAY_E2E=1 pytest -q tests/integration/test_overlay_e2e.py -m "integration and slow"
+```
 
 ## Unified harness: `test_overlay_e2e.py`
 


### PR DESCRIPTION
### Motivation
- Clarify how to run the unified overlay harness via both the original CLI entrypoint and via pytest so contributors can use standard pytest workflows. 
- Provide copy/paste pytest invocations and explain marker usage to simplify running targeted integration scenarios. 
- Surface pytest mode in the top-level testing docs so readers discover the new invocation options. 

### Description
- Reworded `docs/README_TESTING.md` to describe dual execution modes (CLI and pytest) and replaced the previous "not a pytest function" wording. 
- Added a new "Pytest interface" section in `docs/README_TESTING.md` with three example commands for `-k basic`, `-k reconnect`, and `-k listener_two_clients`. 
- Documented pytest markers `integration` and `slow` and provided marker-based filtering examples in `docs/README_TESTING.md`. 
- Updated `README_TESTING.md` to note pytest mode support and `README.md` to include a short pytest reconnect example next to the existing CLI example. 

### Testing
- Docs-only change; no automated tests were required or executed for this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa375ee8c8322961b4a409867f496)