### PR TITLE
Fix compress_layer_level WebUI dropdown

### DIFF
--- a/admin_web/app.js
+++ b/admin_web/app.js
@@ -2526,6 +2526,7 @@ function renderConfigValueCell(item, current) {
   const isSecret = Boolean(item.secret);
   const isReadonly = Boolean(item.readonly);
   const isServiceCatalogSetting = !isSecret && !isReadonly && isServiceCatalogConfigSetting(key);
+  const isCompressLayerLevelSetting = isCompressionLevelConfigSetting(key);
   const isLevelSetting = isLoggingLevelSetting(key, current, item.default);
   const isLogFileSetting = isLogFileConfigSetting(key);
   const isDirectEntrySetting = isDirectEntryConfigSetting(key);
@@ -2551,9 +2552,11 @@ function renderConfigValueCell(item, current) {
         ? renderChoiceSelect(key, current, item.choices)
       : (isBooleanSetting
         ? renderBooleanSelect(key, current)
-        : (isLevelSetting
+        : (isCompressLayerLevelSetting
+          ? renderCompressionLevelSelect(key, current)
+          : (isLevelSetting
           ? renderLogLevelSelect(key, current)
-          : renderTextConfigEditor(key, current)));
+          : renderTextConfigEditor(key, current))));
   return `
     <div class="config-value-cell" data-config-cell="${key}">
       <button class="config-value-display" type="button" data-config-activate="${key}" aria-label="Edit ${key}">
@@ -2638,6 +2641,13 @@ function renderConfigSections(schema, config) {
 }
 
 const LOG_LEVEL_OPTIONS = ['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'];
+const COMPRESS_LEVEL_OPTIONS = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+function isCompressionLevelConfigSetting(key) {
+  const normalizedKey = String(key || '').toLowerCase();
+  return normalizedKey === 'compress_layer_level'
+    || normalizedKey.endsWith('.compress_layer_level');
+}
 
 function isLogFileConfigSetting(key) {
   const normalizedKey = String(key || '').toLowerCase();
@@ -2657,6 +2667,7 @@ function isDirectEntryConfigSetting(key) {
 
 function isLoggingLevelSetting(key, currentValue, defaultValue) {
   const normalizedKey = String(key || '').toLowerCase();
+  if (isCompressionLevelConfigSetting(normalizedKey)) return false;
   if (isLogFileConfigSetting(normalizedKey)) return false;
   if (isDirectEntryConfigSetting(normalizedKey)) return false;
   const byName = normalizedKey === 'log'
@@ -2674,6 +2685,18 @@ function renderLogLevelSelect(key, currentValue) {
   const options = LOG_LEVEL_OPTIONS.map((level) => {
     const selected = level === normalizedCurrent ? ' selected' : '';
     return `<option value="${JSON.stringify(level).replace(/"/g, '&quot;')}"${selected}>${level}</option>`;
+  }).join('');
+  return `<select class="config-editor mono" data-config-key="${key}" autocomplete="off" data-lpignore="true" data-1p-ignore="true">${options}</select>`;
+}
+
+function renderCompressionLevelSelect(key, currentValue) {
+  const normalizedCurrent = String(currentValue ?? '3');
+  const values = COMPRESS_LEVEL_OPTIONS.includes(normalizedCurrent)
+    ? COMPRESS_LEVEL_OPTIONS
+    : [...COMPRESS_LEVEL_OPTIONS, normalizedCurrent];
+  const options = values.map((level) => {
+    const selected = level === normalizedCurrent ? ' selected' : '';
+    return `<option value="${JSON.stringify(Number(level))}"${selected}>${level}</option>`;
   }).join('');
   return `<select class="config-editor mono" data-config-key="${key}" autocomplete="off" data-lpignore="true" data-1p-ignore="true">${options}</select>`;
 }


### PR DESCRIPTION
## Summary

This PR corrects the Admin Web configuration editor so `compress_layer_level` renders as a numeric dropdown with values `0` through `9` instead of being misclassified as a log-level field.

## Problem

In WebAdmin, `compress_layer_level` matched the generic `*_level` heuristic and incorrectly showed log-level options like `CRITICAL` and `INFO` instead of compression levels `0` through `9`.

Minimal repro:
1. Open Admin Web Configuration and inspect `compress_layer_level`.
2. Observe that the dropdown offers logging levels instead of numeric compression levels.

## Changes

- Updated `admin_web/app.js` so `compress_layer_level` is detected as a dedicated compression-level setting.
- Added a dedicated WebUI dropdown renderer for compression levels `0` through `9`.
- Excluded `compress_layer_level` from the generic log-level heuristic so actual log-level fields keep their existing behavior.

## Why This Matters

This prevents operators from selecting invalid compression-level values through the admin page.

## Validation

Manual validation of the Admin Web configuration editor.

## Reviewer Notes

- Focus review on: whether `compress_layer_level` is now excluded from the generic log-level detection path and still saves as a numeric config value
- Suggested reviewers: (@handle)

---

Checklist before merging:

- [x] Tests run locally and CI is expected to pass
- [ ] Linked to any relevant design/architecture docs in `docs/`