### PR TITLE
[codex] Allow iOS WebAdmin local networking

### DIFF
--- a/.github/architecture_traceability.yaml
+++ b/.github/architecture_traceability.yaml
@@ -298,6 +298,7 @@ ARC-CMP-005:
     - tests/unit/test_admin_web_component_parity.py::test_swift_admin_api_live_topic_peers_preserves_throttle_summary
     - ios/tests/test_m3_native_sources.py::test_macos_swift_host_runner_source_exists
     - ios/tests/test_m3_native_sources.py::test_ipserver_packet_tunnel_provider_source_exists
+    - ios/tests/test_m3_native_sources.py::test_ios_packaging_config_includes_native_bridge_and_local_webadmin_ats
     - tests/unit/test_requirements_unit_gaps.py::test_auth_disabled_reports_authenticated_without_session
     - tests/unit/test_requirements_unit_gaps.py::test_auth_required_rejects_bad_login_and_accepts_challenge_proof
     - tests/unit/test_requirements_unit_gaps.py::test_admin_auth_sessions_are_cookie_scoped_per_client

--- a/.github/requirements_traceability.yaml
+++ b/.github/requirements_traceability.yaml
@@ -871,6 +871,7 @@ REQ-ADM-001:
     - tests/unit/test_runner_events.py::test_get_debug_logs_falls_back_to_log_file_when_ring_is_empty
     - tests/unit/test_debug_logging_aliases.py::test_log_file_moves_previous_session_to_lastsession_on_start
     - ios/tests/test_m3_native_sources.py::test_app_tunnel_control_manages_ipserver_profile_without_blocking_main_thread
+    - ios/tests/test_m3_native_sources.py::test_ios_packaging_config_includes_native_bridge_and_local_webadmin_ats
 
 
 REQ-ADM-009:

--- a/docs/IOSAPP_DESIGN.md
+++ b/docs/IOSAPP_DESIGN.md
@@ -314,6 +314,9 @@ Design impact:
 - there must not be platform-specific WebAdmin forks for iOS, Windows, Linux, or macOS
 - packaged builds still need a runtime-accessible bundled copy of the canonical assets
 - the iOS build path must be validated against actual staged bundle contents, not only source-tree assumptions
+- the containing app's WebView must be allowed to load the extension-owned local WebAdmin endpoint over loopback HTTP, currently `http://127.0.0.1:18080/`; Briefcase packaging therefore needs the iOS `Info.plist` App Transport Security key `NSAppTransportSecurity.NSAllowsLocalNetworking=true`
+
+This App Transport Security exception is intentionally narrow. It allows local networking for the containing iOS app so the WebView can reach the on-device WebAdmin service, but it does not grant broad arbitrary WebView HTTP loading. The current source guard for this packaging contract is [ios/tests/test_m3_native_sources.py](/home/ohnoohweh/quic_br/ios/tests/test_m3_native_sources.py), which reads [ios/pyproject.toml](/home/ohnoohweh/quic_br/ios/pyproject.toml) and pins the `NSAllowsLocalNetworking` entry.
 
 ### Outcome 7: The iOS App Now Delivers Real Tunnel User Value
 

--- a/docs/README_TESTING.md
+++ b/docs/README_TESTING.md
@@ -196,7 +196,7 @@ iOS integration testing is shaped differently from the desktop/Linux E2E harness
 
 Current iOS lanes:
 
-- `ios/tests/*`: Python-level unit/facade tests for the iOS companion-app modules. These do not launch an iOS app.
+- `ios/tests/*`: Python-level unit/facade tests for the iOS companion-app modules. These do not launch an iOS app. The source-guard slice also pins iOS packaging metadata such as local-networking App Transport Security allowance for the WebAdmin WebView.
 - [tests/integration/test_ios_e2e.py](../tests/integration/test_ios_e2e.py): host-side integration for the M3 packet-flow contract. It starts a loopback TCP packet-frame peer on macOS and runs a simulated `NEPacketTunnelFlow` adapter in Python. It also starts a host-side ObstacleBridge WS listener plus stimulation targets, then runs the standalone iOS E2E harness code to validate both WS-overlay UDP carriage and WS SecureLink PSK authentication against the host listener. These cases prove app/native provider configuration and iOS-harness bridge behavior without requiring Apple Network Extension entitlements.
 - [tests/integration/test_ios_simulator_e2e.py](../tests/integration/test_ios_simulator_e2e.py): opt-in simulator integration. Pytest starts host-side stimulation services on macOS, builds/updates the standalone Briefcase iOS E2E app, installs that test application into the simulator, launches it, and reads the probe report from the E2E app data container. The implemented simulator probes are host WebSocket reachability, WS overlay UDP service to host UDP echo, and WS SecureLink PSK authentication that is confirmed through the host WebAdmin API.
 

--- a/ios/pyproject.toml
+++ b/ios/pyproject.toml
@@ -38,3 +38,4 @@ requires = [
 [tool.briefcase.app.obstacle_bridge_ios.iOS.info]
 UIFileSharingEnabled = true
 LSSupportsOpeningDocumentsInPlace = true
+NSAppTransportSecurity = { NSAllowsLocalNetworking = true }

--- a/ios/tests/test_m3_native_sources.py
+++ b/ios/tests/test_m3_native_sources.py
@@ -613,14 +613,16 @@ def test_udp_overlay_peer_runtime_source_exists() -> None:
     assert "noteControlSent(" in runtime
 
 
-def test_ios_packaging_config_includes_rubicon_for_native_crypto_bridge() -> None:
+def test_ios_packaging_config_includes_native_bridge_and_local_webadmin_ats() -> None:
     pyproject = tomllib.loads((ROOT / "ios" / "pyproject.toml").read_text(encoding="utf-8"))
 
     app_sources = pyproject["tool"]["briefcase"]["app"]["obstacle_bridge_ios"]["sources"]
     app_requires = pyproject["tool"]["briefcase"]["app"]["obstacle_bridge_ios"]["requires"]
+    ios_info = pyproject["tool"]["briefcase"]["app"]["obstacle_bridge_ios"]["iOS"]["info"]
 
     assert "../admin_web" in app_sources
     assert "rubicon-objc>=0.5.3" in app_requires
+    assert ios_info["NSAppTransportSecurity"] == {"NSAllowsLocalNetworking": True}
 
 
 def test_ipserver_extension_sources_are_swift_only() -> None:


### PR DESCRIPTION
## Summary

Allow the iOS Briefcase packaging metadata to permit local loopback networking so the containing app's WebView can load the on-device WebAdmin endpoint at `http://127.0.0.1:18080/`. The change keeps the allowance narrow by using `NSAppTransportSecurity.NSAllowsLocalNetworking=true` instead of broad arbitrary WebView HTTP loading, then documents and traces that packaging contract.

## Problem

The iOS app serves WebAdmin locally, but iOS App Transport Security can block plain HTTP loads unless the app declares the appropriate local-networking allowance. Without this packaging metadata, the WebView path can fail even though the WebAdmin assets and runtime service are present.

## Changes

- Added `NSAppTransportSecurity.NSAllowsLocalNetworking=true` to `ios/pyproject.toml` for the iOS app metadata.
- Extended `ios/tests/test_m3_native_sources.py` to pin the local WebAdmin ATS packaging contract alongside the native bridge/source checks.
- Documented the need and narrow scope in `docs/IOSAPP_DESIGN.md`.
- Linked the source guard from `docs/README_TESTING.md`.
- Added requirement and architecture traceability links for the new guard.

## Why This Matters

This preserves the intended iOS WebAdmin behavior without relaxing network policy more than necessary. It is iOS packaging metadata only and should not affect the macOS app path.

## Validation

```bash
python3 -m pytest -q ios/tests/test_m3_native_sources.py -k ios_packaging_config_includes_native_bridge_and_local_webadmin_ats
python3 scripts/report_requirements_coverage.py
python3 scripts/report_product_traceability.py
git diff --check
```

Results: focused iOS test passed (`1 passed, 33 deselected`); requirements coverage and product traceability reports completed successfully; `git diff --check` reported no whitespace issues. Commit hooks also passed the README/traceability guard and requirements guard during amend.

## Reviewer Notes

- Focus review on whether `NSAllowsLocalNetworking` is the right minimal ATS key for loopback WebAdmin.
- Focus review on the iOS-only scope: this should not change macOS behavior.
- Suggested validation before merge: run the iOS app on the Mac/iOS validation machine and confirm WebAdmin loads over `127.0.0.1`.

---

Checklist before merging:

- [x] Tests run locally and CI is expected to pass
- [x] `docs/REQUIREMENTS.md` updated when behavior/tests changed
- [x] `README.md` updated when requirement/test set changed
- [x] `.github/requirements_traceability.yaml` updated when requirement IDs changed
- [x] Linked to any relevant design/architecture docs in `docs/`
