### PR TITLE
Add Swift secure-link retry and recovery parity

### DIFF
--- a/ios/native/IPServer/PacketTunnelProvider.swift
+++ b/ios/native/IPServer/PacketTunnelProvider.swift
@@ -1107,13 +1107,31 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             }
 
             if settings.secureLinkMode == "psk" {
+                let rekeyAfterFrames = ObstacleBridgeRuntimeConfig.intValue(from: payload["secure_link_rekey_after_frames"]) ?? 0
+                let rekeyAfterSeconds = ObstacleBridgeRuntimeConfig.doubleValue(from: payload["secure_link_rekey_after_seconds"]) ?? 0.0
+                let retryBackoffInitialMS = ObstacleBridgeRuntimeConfig.intValue(from: payload["secure_link_retry_backoff_initial_ms"]) ?? 1000
+                let retryBackoffMaxMS = ObstacleBridgeRuntimeConfig.intValue(from: payload["secure_link_retry_backoff_max_ms"]) ?? 5000
+                let recoverAfterFailure = ObstacleBridgeRuntimeConfig.boolValue(from: payload["secure_link_recover_after_failure"]) ?? true
+                let recoverDelaySeconds = ObstacleBridgeRuntimeConfig.doubleValue(from: payload["secure_link_recover_delay_seconds"]) ?? 30.0
                 sharedSecureLinkPskTransportAdapter = ObstacleBridgeSecureLinkPskTransportAdapter(
                     runtime: ObstacleBridgeSecureLinkPskRuntime(
                         clientMode: settings.peerHost != nil,
-                        psk: settings.secureLinkPSK
-                    )
+                        psk: settings.secureLinkPSK,
+                        rekeyAfterFrames: rekeyAfterFrames,
+                        rekeyAfterSeconds: rekeyAfterSeconds
+                    ),
+                    retryBackoffInitialMS: retryBackoffInitialMS,
+                    retryBackoffMaxMS: retryBackoffMaxMS,
+                    recoverAfterFailure: recoverAfterFailure,
+                    recoverDelaySeconds: recoverDelaySeconds
                 )
                 summary["secure_link_runtime"] = "ready"
+                summary["secure_link_rekey_after_frames"] = rekeyAfterFrames
+                summary["secure_link_rekey_after_seconds"] = rekeyAfterSeconds
+                summary["secure_link_retry_backoff_initial_ms"] = retryBackoffInitialMS
+                summary["secure_link_retry_backoff_max_ms"] = retryBackoffMaxMS
+                summary["secure_link_recover_after_failure"] = recoverAfterFailure
+                summary["secure_link_recover_delay_seconds"] = recoverDelaySeconds
             }
 
             if sharedCompressLayerRuntime != nil || sharedSecureLinkPskTransportAdapter != nil {
@@ -2513,6 +2531,14 @@ extension PacketTunnelProvider: ObstacleBridgeAdminAPIStateProvider {
                 "connected_since_unix_ts": NSNull(),
                 "authenticated_sessions_total": 0,
                 "rekeys_completed_total": 0,
+                "handshake_attempts_total": 0,
+                "consecutive_failures": 0,
+                "retry_backoff_sec": 0.0,
+                "next_retry_unix_ts": NSNull(),
+                "recovery_enabled": false,
+                "recovery_delay_sec": 0.0,
+                "recovery_reconnect_sec": 0.0,
+                "next_recovery_reconnect_unix_ts": NSNull(),
                 "frames_passed_total": 0,
                 "frames_dropped_total": 0,
                 "peer_subject_id": "",
@@ -2582,6 +2608,14 @@ extension PacketTunnelProvider: ObstacleBridgeAdminAPIStateProvider {
             "connected_since_unix_ts": snapshot.sessionID == 0 ? NSNull() : (secureLinkConnectedSinceUnixTS ?? nowUnixTS),
             "authenticated_sessions_total": snapshot.authenticatedSessionsTotal,
             "rekeys_completed_total": snapshot.rekeysCompletedTotal,
+            "handshake_attempts_total": snapshot.handshakeAttemptsTotal,
+            "consecutive_failures": snapshot.consecutiveFailures,
+            "retry_backoff_sec": snapshot.retryBackoffSec,
+            "next_retry_unix_ts": snapshot.nextRetryUnixTs ?? NSNull(),
+            "recovery_enabled": snapshot.recoveryEnabled,
+            "recovery_delay_sec": snapshot.recoveryDelaySec,
+            "recovery_reconnect_sec": snapshot.recoveryReconnectSec,
+            "next_recovery_reconnect_unix_ts": snapshot.nextRecoveryReconnectUnixTs ?? NSNull(),
             "last_rekey_trigger": snapshot.lastRekeyTrigger,
             "frames_passed_total": snapshot.framesPassedTotal,
             "frames_dropped_total": snapshot.framesDroppedTotal,

--- a/ios/native/ObstacleBridgeApp/ObstacleBridgeHostRunner.swift
+++ b/ios/native/ObstacleBridgeApp/ObstacleBridgeHostRunner.swift
@@ -1851,6 +1851,14 @@ final class ObstacleBridgeHostRunner {
                 "connected_since_unix_ts": NSNull(),
                 "authenticated_sessions_total": 0,
                 "rekeys_completed_total": 0,
+                "handshake_attempts_total": 0,
+                "consecutive_failures": 0,
+                "retry_backoff_sec": 0.0,
+                "next_retry_unix_ts": NSNull(),
+                "recovery_enabled": false,
+                "recovery_delay_sec": 0.0,
+                "recovery_reconnect_sec": 0.0,
+                "next_recovery_reconnect_unix_ts": NSNull(),
                 "frames_passed_total": 0,
                 "frames_dropped_total": 0,
                 "peer_subject_id": "",
@@ -1914,6 +1922,14 @@ final class ObstacleBridgeHostRunner {
             "connected_since_unix_ts": snapshot.sessionID == 0 ? NSNull() : (secureLinkConnectedSinceUnixTs ?? nowUnix),
             "authenticated_sessions_total": snapshot.authenticatedSessionsTotal,
             "rekeys_completed_total": snapshot.rekeysCompletedTotal,
+            "handshake_attempts_total": snapshot.handshakeAttemptsTotal,
+            "consecutive_failures": snapshot.consecutiveFailures,
+            "retry_backoff_sec": snapshot.retryBackoffSec,
+            "next_retry_unix_ts": snapshot.nextRetryUnixTs ?? NSNull(),
+            "recovery_enabled": snapshot.recoveryEnabled,
+            "recovery_delay_sec": snapshot.recoveryDelaySec,
+            "recovery_reconnect_sec": snapshot.recoveryReconnectSec,
+            "next_recovery_reconnect_unix_ts": snapshot.nextRecoveryReconnectUnixTs ?? NSNull(),
             "last_rekey_trigger": snapshot.lastRekeyTrigger,
             "frames_passed_total": snapshot.framesPassedTotal,
             "frames_dropped_total": snapshot.framesDroppedTotal,
@@ -2559,13 +2575,31 @@ final class ObstacleBridgeHostRunner {
             }
 
             if settings.secureLinkMode == "psk" {
+                let rekeyAfterFrames = Self.intValue(from: runtimeConfig["secure_link_rekey_after_frames"]) ?? 0
+                let rekeyAfterSeconds = Self.doubleValue(from: runtimeConfig["secure_link_rekey_after_seconds"]) ?? 0.0
+                let retryBackoffInitialMS = Self.intValue(from: runtimeConfig["secure_link_retry_backoff_initial_ms"]) ?? 1000
+                let retryBackoffMaxMS = Self.intValue(from: runtimeConfig["secure_link_retry_backoff_max_ms"]) ?? 5000
+                let recoverAfterFailure = Self.boolValue(from: runtimeConfig["secure_link_recover_after_failure"]) ?? true
+                let recoverDelaySeconds = Self.doubleValue(from: runtimeConfig["secure_link_recover_delay_seconds"]) ?? 30.0
                 sharedSecureLinkPskTransportAdapter = ObstacleBridgeSecureLinkPskTransportAdapter(
                     runtime: ObstacleBridgeSecureLinkPskRuntime(
                         clientMode: settings.peerHost != nil,
-                        psk: settings.secureLinkPSK
-                    )
+                        psk: settings.secureLinkPSK,
+                        rekeyAfterFrames: rekeyAfterFrames,
+                        rekeyAfterSeconds: rekeyAfterSeconds
+                    ),
+                    retryBackoffInitialMS: retryBackoffInitialMS,
+                    retryBackoffMaxMS: retryBackoffMaxMS,
+                    recoverAfterFailure: recoverAfterFailure,
+                    recoverDelaySeconds: recoverDelaySeconds
                 )
                 summary["secure_link_runtime"] = "ready"
+                summary["secure_link_rekey_after_frames"] = rekeyAfterFrames
+                summary["secure_link_rekey_after_seconds"] = rekeyAfterSeconds
+                summary["secure_link_retry_backoff_initial_ms"] = retryBackoffInitialMS
+                summary["secure_link_retry_backoff_max_ms"] = retryBackoffMaxMS
+                summary["secure_link_recover_after_failure"] = recoverAfterFailure
+                summary["secure_link_recover_delay_seconds"] = recoverDelaySeconds
             }
 
             if sharedCompressLayerRuntime != nil || sharedSecureLinkPskTransportAdapter != nil {

--- a/ios/native/ObstacleBridgeShared/ObstacleBridgeOverlayLayerTransportAdapter.swift
+++ b/ios/native/ObstacleBridgeShared/ObstacleBridgeOverlayLayerTransportAdapter.swift
@@ -100,6 +100,14 @@ final class ObstacleBridgeOverlayLayerTransportAdapter {
         return OutboundSnapshot(emittedFrames: snapshot.emittedFrames)
     }
 
+    func pollSecureLinkDueFrames() throws -> OutboundSnapshot {
+        guard let secureLinkAdapter else {
+            return OutboundSnapshot(emittedFrames: [])
+        }
+        let snapshot = try secureLinkAdapter.pollDueFrames()
+        return OutboundSnapshot(emittedFrames: snapshot.emittedFrames)
+    }
+
     func connectionLayersSnapshot(
         transport: String,
         transportConnected: Bool,

--- a/ios/native/ObstacleBridgeShared/ObstacleBridgeQuicOverlayTransportOwner.swift
+++ b/ios/native/ObstacleBridgeShared/ObstacleBridgeQuicOverlayTransportOwner.swift
@@ -59,6 +59,7 @@ final class ObstacleBridgeQuicOverlayTransportOwner {
     private var reconnectScheduled = false
     private var reconnectWorkItem: DispatchWorkItem?
     private var nextReconnectAttemptDeadlineNS: UInt64?
+    private var secureLinkDueTimer: DispatchSourceTimer?
     private var lowerLayerFallbackWorkItem: DispatchWorkItem?
     private var lowerLayerFallbackDeadlineNS: UInt64?
     private var startupMuxFramesSent = false
@@ -173,6 +174,7 @@ final class ObstacleBridgeQuicOverlayTransportOwner {
         guard !started else { return }
         guard !peerHost.isEmpty, peerPort > 0 else { return }
         started = true
+        startSecureLinkDueTimer()
         connectOverlay()
     }
 
@@ -185,6 +187,8 @@ final class ObstacleBridgeQuicOverlayTransportOwner {
         nextReconnectAttemptDeadlineNS = nil
         reconnectWorkItem?.cancel()
         reconnectWorkItem = nil
+        secureLinkDueTimer?.cancel()
+        secureLinkDueTimer = nil
         lowerLayerFallbackWorkItem?.cancel()
         lowerLayerFallbackWorkItem = nil
         lowerLayerFallbackDeadlineNS = nil
@@ -515,6 +519,40 @@ final class ObstacleBridgeQuicOverlayTransportOwner {
         }
     }
 
+    private func startSecureLinkDueTimer() {
+        guard secureLinkDueTimer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + .seconds(1), repeating: .seconds(1))
+        timer.setEventHandler { [weak self] in
+            self?.handleSecureLinkDueTimer()
+        }
+        timer.resume()
+        secureLinkDueTimer = timer
+    }
+
+    private func handleSecureLinkDueTimer() {
+        guard started, overlayConnected else {
+            return
+        }
+        flushDueSecureLinkFramesIfNeeded()
+    }
+
+    private func flushDueSecureLinkFramesIfNeeded() {
+        guard let adapter = overlayLayerTransportAdapter else {
+            return
+        }
+        do {
+            let snapshot = try adapter.pollSecureLinkDueFrames()
+            guard !snapshot.emittedFrames.isEmpty else {
+                return
+            }
+            sendTransportFrames(snapshot.emittedFrames)
+            updateLowerLayerFallback()
+        } catch {
+            eventSink?("quic_overlay_secure_link_due_frames_failed", ["error": error.localizedDescription])
+        }
+    }
+
     private func scheduleReconnect() {
         guard started, !reconnectScheduled else { return }
         advancePeerCandidate()
@@ -627,10 +665,27 @@ final class ObstacleBridgeQuicOverlayTransportOwner {
             lowerLayerFallbackDeadlineNS = nil
             return
         }
-        if lowerLayerFallbackWorkItem != nil {
+        let delayNS: UInt64
+        if status.authFailCode != 0 {
+            guard status.recoveryEnabled, status.recoveryReconnectSec > 0.0 else {
+                lowerLayerFallbackWorkItem?.cancel()
+                lowerLayerFallbackWorkItem = nil
+                lowerLayerFallbackDeadlineNS = nil
+                return
+            }
+            delayNS = UInt64(max(0.0, status.recoveryReconnectSec) * 1_000_000_000.0)
+        } else {
+            delayNS = Self.lowerLayerUnavailableFallbackNS
+        }
+        lowerLayerFallbackWorkItem?.cancel()
+        lowerLayerFallbackWorkItem = nil
+        if delayNS == 0 {
+            let reason = status.authFailCode != 0 ? "secure_link_failed" : "app_not_ready"
+            eventSink?("quic_overlay_lower_layer_unavailable", ["reason": reason, "auth_fail_code": status.authFailCode])
+            forceReconnectForUnavailableChannel()
             return
         }
-        lowerLayerFallbackDeadlineNS = DispatchTime.now().uptimeNanoseconds + Self.lowerLayerUnavailableFallbackNS
+        lowerLayerFallbackDeadlineNS = DispatchTime.now().uptimeNanoseconds + delayNS
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.lowerLayerFallbackWorkItem = nil
@@ -643,7 +698,7 @@ final class ObstacleBridgeQuicOverlayTransportOwner {
             self.forceReconnectForUnavailableChannel()
         }
         lowerLayerFallbackWorkItem = workItem
-        queue.asyncAfter(deadline: .now() + .nanoseconds(Int(Self.lowerLayerUnavailableFallbackNS)), execute: workItem)
+        queue.asyncAfter(deadline: .now() + .nanoseconds(Int(delayNS)), execute: workItem)
     }
 
     private func forceReconnectForUnavailableChannel() {

--- a/ios/native/ObstacleBridgeShared/ObstacleBridgeRuntimeConfig.swift
+++ b/ios/native/ObstacleBridgeShared/ObstacleBridgeRuntimeConfig.swift
@@ -444,6 +444,12 @@ enum ObstacleBridgeRuntimeConfig {
                 schemaItem(key: "secure_link", description: "Enable SecureLink", defaultValue: false),
                 schemaItem(key: "secure_link_mode", description: "SecureLink mode", defaultValue: "off", choices: ["off", "psk", "cert"]),
                 schemaItem(key: "secure_link_psk", description: "SecureLink PSK secret", defaultValue: "", secret: true),
+                schemaItem(key: "secure_link_rekey_after_frames", description: "Automatically rekey PSK sessions after this many protected data frames. 0 disables frame-triggered rekey.", defaultValue: 0),
+                schemaItem(key: "secure_link_rekey_after_seconds", description: "Automatically rekey PSK sessions after this many authenticated seconds. 0 disables time-triggered rekey.", defaultValue: 0.0),
+                schemaItem(key: "secure_link_retry_backoff_initial_ms", description: "Initial SecureLink client retry backoff after authentication failure, in milliseconds.", defaultValue: 1000),
+                schemaItem(key: "secure_link_retry_backoff_max_ms", description: "Maximum SecureLink client retry backoff after repeated authentication failures, in milliseconds.", defaultValue: 5000),
+                schemaItem(key: "secure_link_recover_after_failure", description: "Whether SecureLink client failures should trigger a delayed transport reconnect recovery.", defaultValue: true),
+                schemaItem(key: "secure_link_recover_delay_seconds", description: "Seconds to wait before the SecureLink client forces a transport reconnect after persistent failure.", defaultValue: 30.0),
             ],
             "compress_layer": [
                 schemaItem(key: "compress_layer", description: "Enable transport compression", defaultValue: false),
@@ -726,6 +732,24 @@ enum ObstacleBridgeRuntimeConfig {
         }
         if payload["secure_link_psk"] == nil {
             payload["secure_link_psk"] = ""
+        }
+        if payload["secure_link_rekey_after_frames"] == nil {
+            payload["secure_link_rekey_after_frames"] = 0
+        }
+        if payload["secure_link_rekey_after_seconds"] == nil {
+            payload["secure_link_rekey_after_seconds"] = 0.0
+        }
+        if payload["secure_link_retry_backoff_initial_ms"] == nil {
+            payload["secure_link_retry_backoff_initial_ms"] = 1000
+        }
+        if payload["secure_link_retry_backoff_max_ms"] == nil {
+            payload["secure_link_retry_backoff_max_ms"] = 5000
+        }
+        if payload["secure_link_recover_after_failure"] == nil {
+            payload["secure_link_recover_after_failure"] = true
+        }
+        if payload["secure_link_recover_delay_seconds"] == nil {
+            payload["secure_link_recover_delay_seconds"] = 30.0
         }
         if payload["compress_layer"] == nil {
             payload["compress_layer"] = false

--- a/ios/native/ObstacleBridgeShared/ObstacleBridgeSecureLinkPskRuntime.swift
+++ b/ios/native/ObstacleBridgeShared/ObstacleBridgeSecureLinkPskRuntime.swift
@@ -67,6 +67,14 @@ final class ObstacleBridgeSecureLinkPskRuntime {
         var appDataSendingBlocked: Bool
         var framesPassedTotal: Int
         var framesDroppedTotal: Int
+        var handshakeAttemptsTotal: Int
+        var consecutiveFailures: Int
+        var retryBackoffSec: TimeInterval
+        var nextRetryUnixTs: TimeInterval?
+        var recoveryEnabled: Bool
+        var recoveryDelaySec: TimeInterval
+        var recoveryReconnectSec: TimeInterval
+        var nextRecoveryReconnectUnixTs: TimeInterval?
     }
 
     private let clientMode: Bool
@@ -74,6 +82,8 @@ final class ObstacleBridgeSecureLinkPskRuntime {
     private let randomBytes: (Int) -> Data
     private let sessionIDProvider: () -> UInt64
     private let timeProvider: () -> TimeInterval
+    private let rekeyAfterFrames: Int
+    private let rekeyAfterSeconds: TimeInterval
 
     private var sessionID: UInt64 = 0
     private var authenticated = false
@@ -104,10 +114,13 @@ final class ObstacleBridgeSecureLinkPskRuntime {
     private var framesPassedTotal = 0
     private var framesDroppedTotal = 0
     private let unixTimeProvider: () -> TimeInterval
+    private var rekeyDueMono: TimeInterval?
 
     init(
         clientMode: Bool,
         psk: String,
+        rekeyAfterFrames: Int = 0,
+        rekeyAfterSeconds: TimeInterval = 0.0,
         randomBytes: ((Int) -> Data)? = nil,
         sessionIDProvider: (() -> UInt64)? = nil,
         timeProvider: (() -> TimeInterval)? = nil,
@@ -115,6 +128,8 @@ final class ObstacleBridgeSecureLinkPskRuntime {
     ) {
         self.clientMode = clientMode
         self.psk = Data(psk.utf8)
+        self.rekeyAfterFrames = max(0, rekeyAfterFrames)
+        self.rekeyAfterSeconds = max(0.0, rekeyAfterSeconds)
         self.randomBytes = randomBytes ?? { count in
             Data((0..<count).map { _ in UInt8.random(in: 0...UInt8.max) })
         }
@@ -155,7 +170,15 @@ final class ObstacleBridgeSecureLinkPskRuntime {
             trustValidationState: trustValidationState,
             appDataSendingBlocked: clientRekeyHoldAfterCommit,
             framesPassedTotal: framesPassedTotal,
-            framesDroppedTotal: framesDroppedTotal
+            framesDroppedTotal: framesDroppedTotal,
+            handshakeAttemptsTotal: 0,
+            consecutiveFailures: 0,
+            retryBackoffSec: 0.0,
+            nextRetryUnixTs: nil,
+            recoveryEnabled: false,
+            recoveryDelaySec: 0.0,
+            recoveryReconnectSec: 0.0,
+            nextRecoveryReconnectUnixTs: nil
         )
     }
 
@@ -195,6 +218,7 @@ final class ObstacleBridgeSecureLinkPskRuntime {
 
     func sendApp(_ payload: Data) throws -> OutboundSnapshot {
         expireHandshakeIfNeeded()
+        let timeTriggeredFrames = try maybeTriggerTimeBasedRekey()
         guard !clientRekeyHoldAfterCommit else {
             throw ObstacleBridgeSecureLinkPskRuntimeError.invalidState
         }
@@ -215,9 +239,12 @@ final class ObstacleBridgeSecureLinkPskRuntime {
         let ciphertext = try seal(payload: payload, key: outboundKey, counter: txCounter, aad: aad)
         let frame = aad + ciphertext
         txCounter &+= 1
+        var emittedFrames = timeTriggeredFrames
+        emittedFrames.append(frame)
+        emittedFrames.append(contentsOf: try maybeTriggerFrameBasedRekey())
         return OutboundSnapshot(
             sent: true,
-            emittedFrames: [frame],
+            emittedFrames: emittedFrames,
             authenticated: authenticated,
             sessionID: sessionID,
             txCounter: txCounter
@@ -226,6 +253,7 @@ final class ObstacleBridgeSecureLinkPskRuntime {
 
     func handleInboundFrame(_ payload: Data) -> InboundSnapshot {
         expireHandshakeIfNeeded()
+        _ = try? maybeTriggerTimeBasedRekey()
         guard let frame = ObstacleBridgeSecureLinkPskCodec.parseFrame(payload) else {
             return fail(sessionID: 0, code: Self.authFailDecode)
         }
@@ -281,22 +309,7 @@ final class ObstacleBridgeSecureLinkPskRuntime {
         guard pendingSessionID == 0 else {
             throw ObstacleBridgeSecureLinkPskRuntimeError.invalidState
         }
-        let nextSessionID = nextSessionID()
-        let nextClientNonce = Data(randomBytes(32).prefix(32))
-        pendingSessionID = nextSessionID
-        pendingClientNonce = nextClientNonce
-        pendingServerNonce = Data()
-        pendingC2SKey = nil
-        pendingS2CKey = nil
-        lastRekeyTrigger = "operator"
-        recordEvent("rekey_started")
-        let payload = nextClientNonce + Data([UInt8(Self.capabilityPSKV1), 0])
-        let frame = ObstacleBridgeSecureLinkPskCodec.buildFrame(
-            slType: Self.typeRekeyHello,
-            sessionID: nextSessionID,
-            counter: 0,
-            payload: payload
-        )
+        let frame = try startClientRekey(trigger: "operator")
         return OutboundSnapshot(
             sent: true,
             emittedFrames: [frame],
@@ -304,6 +317,11 @@ final class ObstacleBridgeSecureLinkPskRuntime {
             sessionID: sessionID,
             txCounter: txCounter
         )
+    }
+
+    func pollDueFrames() throws -> [Data] {
+        expireHandshakeIfNeeded()
+        return try maybeTriggerTimeBasedRekey()
     }
 
     private func handleClientHello(sessionID: UInt64, body: Data) -> InboundSnapshot {
@@ -453,6 +471,7 @@ final class ObstacleBridgeSecureLinkPskRuntime {
             disconnectDetail = ""
             trustValidationState = "validated"
             recordEvent("authenticated")
+            scheduleTimeBasedRekeyIfNeeded()
         }
         framesPassedTotal &+= 1
         return InboundSnapshot(
@@ -632,6 +651,7 @@ final class ObstacleBridgeSecureLinkPskRuntime {
         handshakeStartedAt = nil
         clientRekeyHoldAfterCommit = false
         clearPendingRekey()
+        clearRekeySchedule()
         disconnectReason = "auth_failed"
         disconnectDetail = "code=\(code)"
         trustValidationState = "failed"
@@ -670,6 +690,7 @@ final class ObstacleBridgeSecureLinkPskRuntime {
         clientHandshakeProofSent = false
         lastAuthFailCode = 0
         clientRekeyHoldAfterCommit = false
+        clearRekeySchedule()
         lastEvent = keepSessionID ? lastEvent : "bootstrap"
         lastEventUnixTs = keepSessionID ? lastEventUnixTs : nil
         authenticatedSessionsTotal = keepSessionID ? authenticatedSessionsTotal : 0
@@ -739,6 +760,7 @@ final class ObstacleBridgeSecureLinkPskRuntime {
         trustValidationState = "validated"
         recordEvent("rekey_completed")
         clearPendingRekey()
+        scheduleTimeBasedRekeyIfNeeded()
     }
 
     private func nextSessionID() -> UInt64 {
@@ -773,6 +795,66 @@ final class ObstacleBridgeSecureLinkPskRuntime {
         default:
             return "auth_failed"
         }
+    }
+
+    private func startClientRekey(trigger: String) throws -> Data {
+        guard clientMode, authenticated, peerConfirmedAuthenticated, sessionID > 0, pendingSessionID == 0 else {
+            throw ObstacleBridgeSecureLinkPskRuntimeError.invalidState
+        }
+        let nextSessionID = nextSessionID()
+        let nextClientNonce = Data(randomBytes(32).prefix(32))
+        pendingSessionID = nextSessionID
+        pendingClientNonce = nextClientNonce
+        pendingServerNonce = Data()
+        pendingC2SKey = nil
+        pendingS2CKey = nil
+        lastRekeyTrigger = trigger
+        clearRekeySchedule()
+        recordEvent("rekey_started")
+        let payload = nextClientNonce + Data([UInt8(Self.capabilityPSKV1), 0])
+        return ObstacleBridgeSecureLinkPskCodec.buildFrame(
+            slType: Self.typeRekeyHello,
+            sessionID: nextSessionID,
+            counter: 0,
+            payload: payload
+        )
+    }
+
+    private func maybeTriggerFrameBasedRekey() throws -> [Data] {
+        guard clientMode, rekeyAfterFrames > 0, authenticated, peerConfirmedAuthenticated, pendingSessionID == 0 else {
+            return []
+        }
+        let sentFrames = max(0, Int(txCounter) - 1 - (clientHandshakeProofSent ? 1 : 0))
+        guard sentFrames >= rekeyAfterFrames else {
+            return []
+        }
+        return [try startClientRekey(trigger: "frame_threshold")]
+    }
+
+    private func maybeTriggerTimeBasedRekey() throws -> [Data] {
+        guard clientMode, rekeyAfterSeconds > 0.0, authenticated, peerConfirmedAuthenticated, pendingSessionID == 0 else {
+            return []
+        }
+        guard let rekeyDueMono else {
+            scheduleTimeBasedRekeyIfNeeded()
+            return []
+        }
+        guard timeProvider() >= rekeyDueMono else {
+            return []
+        }
+        return [try startClientRekey(trigger: "time_threshold")]
+    }
+
+    private func scheduleTimeBasedRekeyIfNeeded() {
+        guard clientMode, rekeyAfterSeconds > 0.0, authenticated, peerConfirmedAuthenticated, pendingSessionID == 0 else {
+            clearRekeySchedule()
+            return
+        }
+        rekeyDueMono = timeProvider() + rekeyAfterSeconds
+    }
+
+    private func clearRekeySchedule() {
+        rekeyDueMono = nil
     }
 
     private func seal(payload: Data, key: Data, counter: UInt64, aad: Data) throws -> Data {

--- a/ios/native/ObstacleBridgeShared/ObstacleBridgeSecureLinkPskTransportAdapter.swift
+++ b/ios/native/ObstacleBridgeShared/ObstacleBridgeSecureLinkPskTransportAdapter.swift
@@ -18,14 +18,51 @@ final class ObstacleBridgeSecureLinkPskTransportAdapter {
     }
 
     private let runtime: ObstacleBridgeSecureLinkPskRuntime
+    private let retryBackoffInitialSec: TimeInterval
+    private let retryBackoffMaxSec: TimeInterval
+    private let recoverAfterFailure: Bool
+    private let recoverDelaySec: TimeInterval
+    private let timeProvider: () -> TimeInterval
+    private let unixTimeProvider: () -> TimeInterval
     private var pendingPayloads: [Data] = []
+    private var transportConnected = false
+    private var handshakeAttemptsTotal = 0
+    private var consecutiveFailures = 0
+    private var retryNotBeforeMono: TimeInterval = 0.0
+    private var retryNotBeforeUnixTs: TimeInterval?
+    private var recoveryNotBeforeMono: TimeInterval = 0.0
+    private var recoveryNotBeforeUnixTs: TimeInterval?
 
-    init(runtime: ObstacleBridgeSecureLinkPskRuntime) {
+    init(
+        runtime: ObstacleBridgeSecureLinkPskRuntime,
+        retryBackoffInitialMS: Int = 1000,
+        retryBackoffMaxMS: Int = 5000,
+        recoverAfterFailure: Bool = true,
+        recoverDelaySeconds: TimeInterval = 30.0,
+        timeProvider: (() -> TimeInterval)? = nil,
+        unixTimeProvider: (() -> TimeInterval)? = nil
+    ) {
         self.runtime = runtime
+        self.retryBackoffInitialSec = max(0.0, Double(max(0, retryBackoffInitialMS)) / 1000.0)
+        self.retryBackoffMaxSec = max(self.retryBackoffInitialSec, Double(max(0, retryBackoffMaxMS)) / 1000.0)
+        self.recoverAfterFailure = recoverAfterFailure
+        self.recoverDelaySec = max(0.0, recoverDelaySeconds)
+        self.timeProvider = timeProvider ?? { ProcessInfo.processInfo.systemUptime }
+        self.unixTimeProvider = unixTimeProvider ?? { Date().timeIntervalSince1970 }
     }
 
     func statusSnapshot() -> ObstacleBridgeSecureLinkPskRuntime.StatusSnapshot {
-        runtime.statusSnapshot()
+        var snapshot = runtime.statusSnapshot()
+        let nowMono = timeProvider()
+        snapshot.handshakeAttemptsTotal = handshakeAttemptsTotal
+        snapshot.consecutiveFailures = consecutiveFailures
+        snapshot.retryBackoffSec = max(0.0, retryNotBeforeMono - nowMono)
+        snapshot.nextRetryUnixTs = retryNotBeforeUnixTs
+        snapshot.recoveryEnabled = snapshot.clientMode ? recoverAfterFailure : false
+        snapshot.recoveryDelaySec = snapshot.clientMode ? recoverDelaySec : 0.0
+        snapshot.recoveryReconnectSec = max(0.0, recoveryNotBeforeMono - nowMono)
+        snapshot.nextRecoveryReconnectUnixTs = recoveryNotBeforeUnixTs
+        return snapshot
     }
 
     func requestSecureLinkRekey() throws -> OutboundSnapshot {
@@ -38,14 +75,43 @@ final class ObstacleBridgeSecureLinkPskTransportAdapter {
         )
     }
 
+    func pollDueFrames() throws -> OutboundSnapshot {
+        var emittedFrames = try runtime.pollDueFrames()
+        if emittedFrames.isEmpty,
+           transportConnected,
+           shouldRetryClientHandshake(nowMono: timeProvider()) {
+            let handshake = try runtime.beginClientHandshake()
+            handshakeAttemptsTotal += 1
+            clearRetrySchedule()
+            emittedFrames.append(contentsOf: handshake.emittedFrames)
+        }
+        return OutboundSnapshot(
+            emittedFrames: emittedFrames,
+            queuedPayloads: pendingPayloads.count,
+            authenticated: runtime.statusSnapshot().authenticated,
+            sessionID: runtime.statusSnapshot().sessionID
+        )
+    }
+
     func handleTransportDisconnected() {
+        transportConnected = false
         pendingPayloads.removeAll(keepingCapacity: false)
         runtime.handleTransportDisconnected()
     }
 
     func handleTransportConnected() throws -> OutboundSnapshot {
+        transportConnected = true
         let status = runtime.statusSnapshot()
         guard status.clientMode, !status.authenticated else {
+            return OutboundSnapshot(
+                emittedFrames: [],
+                queuedPayloads: pendingPayloads.count,
+                authenticated: status.authenticated,
+                sessionID: status.sessionID
+            )
+        }
+        let nowMono = timeProvider()
+        if recoveryNotBeforeMono > nowMono || retryNotBeforeMono > nowMono {
             return OutboundSnapshot(
                 emittedFrames: [],
                 queuedPayloads: pendingPayloads.count,
@@ -63,6 +129,7 @@ final class ObstacleBridgeSecureLinkPskTransportAdapter {
         }
 
         let handshake = try runtime.beginClientHandshake()
+        handshakeAttemptsTotal += 1
         let emittedFrames = handshake.emittedFrames
 
         let updatedStatus = runtime.statusSnapshot()
@@ -108,13 +175,18 @@ final class ObstacleBridgeSecureLinkPskTransportAdapter {
     }
 
     func handleInboundFrame(_ payload: Data) -> InboundSnapshot {
+        let previousStatus = runtime.statusSnapshot()
         let snapshot = runtime.handleInboundFrame(payload)
         var emittedFrames = snapshot.emittedFrames
         let deliveredPayloads = snapshot.deliveredPayloads
         if snapshot.authFailCode != nil {
             pendingPayloads.removeAll()
+            handleClientAuthFailure(wasAuthenticated: previousStatus.authenticated)
         }
         let status = runtime.statusSnapshot()
+        if status.authenticated {
+            resetClientRetryPolicy()
+        }
         if status.authenticated, !status.appDataSendingBlocked, !pendingPayloads.isEmpty {
             do {
                 emittedFrames.append(contentsOf: try flushPendingPayloads())
@@ -148,5 +220,64 @@ final class ObstacleBridgeSecureLinkPskTransportAdapter {
             pendingPayloads = payloads + pendingPayloads
             throw error
         }
+    }
+
+    private func handleClientAuthFailure(wasAuthenticated: Bool) {
+        let status = runtime.statusSnapshot()
+        guard status.clientMode else {
+            return
+        }
+        if wasAuthenticated {
+            clearRetrySchedule()
+            if transportConnected && recoverAfterFailure && recoverDelaySec > 0.0 {
+                let nowMono = timeProvider()
+                recoveryNotBeforeMono = nowMono + recoverDelaySec
+                recoveryNotBeforeUnixTs = unixTimeProvider() + recoverDelaySec
+            } else {
+                clearRecoverySchedule()
+            }
+            return
+        }
+        guard transportConnected, retryBackoffMaxSec > 0.0 else {
+            return
+        }
+        if recoveryNotBeforeMono > timeProvider() {
+            return
+        }
+        consecutiveFailures += 1
+        let exponent = max(0, consecutiveFailures - 1)
+        let delaySec = min(retryBackoffMaxSec, retryBackoffInitialSec * pow(2.0, Double(exponent)))
+        retryNotBeforeMono = timeProvider() + delaySec
+        retryNotBeforeUnixTs = unixTimeProvider() + delaySec
+    }
+
+    private func resetClientRetryPolicy() {
+        clearRetrySchedule()
+        clearRecoverySchedule()
+        consecutiveFailures = 0
+    }
+
+    private func clearRetrySchedule() {
+        retryNotBeforeMono = 0.0
+        retryNotBeforeUnixTs = nil
+    }
+
+    private func clearRecoverySchedule() {
+        recoveryNotBeforeMono = 0.0
+        recoveryNotBeforeUnixTs = nil
+    }
+
+    private func shouldRetryClientHandshake(nowMono: TimeInterval) -> Bool {
+        let status = runtime.statusSnapshot()
+        guard status.clientMode,
+              transportConnected,
+              !status.authenticated,
+              status.authFailCode != 0,
+              retryNotBeforeMono > 0.0,
+              retryNotBeforeMono <= nowMono,
+              !(recoveryNotBeforeMono > nowMono) else {
+            return false
+        }
+        return true
     }
 }

--- a/ios/native/ObstacleBridgeShared/ObstacleBridgeTcpOverlayTransportOwner.swift
+++ b/ios/native/ObstacleBridgeShared/ObstacleBridgeTcpOverlayTransportOwner.swift
@@ -58,6 +58,7 @@ final class ObstacleBridgeTcpOverlayTransportOwner {
     private var reconnectScheduled = false
     private var reconnectWorkItem: DispatchWorkItem?
     private var nextReconnectAttemptDeadlineNS: UInt64?
+    private var secureLinkDueTimer: DispatchSourceTimer?
     private var lowerLayerFallbackWorkItem: DispatchWorkItem?
     private var lowerLayerFallbackDeadlineNS: UInt64?
     private var peerCandidates: [ResolvedAddress] = []
@@ -172,6 +173,7 @@ final class ObstacleBridgeTcpOverlayTransportOwner {
             return
         }
         started = true
+        startSecureLinkDueTimer()
         if !peerHost.isEmpty, peerPort > 0 {
             connectOverlay()
             return
@@ -189,6 +191,8 @@ final class ObstacleBridgeTcpOverlayTransportOwner {
         nextReconnectAttemptDeadlineNS = nil
         reconnectWorkItem?.cancel()
         reconnectWorkItem = nil
+        secureLinkDueTimer?.cancel()
+        secureLinkDueTimer = nil
         lowerLayerFallbackWorkItem?.cancel()
         lowerLayerFallbackWorkItem = nil
         lowerLayerFallbackDeadlineNS = nil
@@ -742,6 +746,44 @@ final class ObstacleBridgeTcpOverlayTransportOwner {
         }
     }
 
+    private func startSecureLinkDueTimer() {
+        guard secureLinkDueTimer == nil else {
+            return
+        }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + .seconds(1), repeating: .seconds(1))
+        timer.setEventHandler { [weak self] in
+            self?.handleSecureLinkDueTimer()
+        }
+        timer.resume()
+        secureLinkDueTimer = timer
+    }
+
+    private func handleSecureLinkDueTimer() {
+        guard started, overlayConnected else {
+            return
+        }
+        flushDueSecureLinkFramesIfNeeded()
+    }
+
+    private func flushDueSecureLinkFramesIfNeeded() {
+        guard let adapter = overlayLayerTransportAdapter else {
+            return
+        }
+        do {
+            let snapshot = try adapter.pollSecureLinkDueFrames()
+            guard !snapshot.emittedFrames.isEmpty else {
+                return
+            }
+            for frame in snapshot.emittedFrames {
+                sendOverlayTransportPayload(frame)
+            }
+            updateLowerLayerFallback()
+        } catch {
+            eventSink?("tcp_overlay_secure_link_due_frames_failed", ["error": error.localizedDescription])
+        }
+    }
+
     private func resetOverlayTransportEpoch() {
         overlayLayerTransportAdapter?.handleTransportDisconnected()
         secureLinkHandshakePrimed = false
@@ -768,10 +810,27 @@ final class ObstacleBridgeTcpOverlayTransportOwner {
             lowerLayerFallbackDeadlineNS = nil
             return
         }
-        if lowerLayerFallbackWorkItem != nil {
+        let delayNS: UInt64
+        if status.authFailCode != 0 {
+            guard status.recoveryEnabled, status.recoveryReconnectSec > 0.0 else {
+                lowerLayerFallbackWorkItem?.cancel()
+                lowerLayerFallbackWorkItem = nil
+                lowerLayerFallbackDeadlineNS = nil
+                return
+            }
+            delayNS = UInt64(max(0.0, status.recoveryReconnectSec) * 1_000_000_000.0)
+        } else {
+            delayNS = Self.lowerLayerUnavailableFallbackNS
+        }
+        lowerLayerFallbackWorkItem?.cancel()
+        lowerLayerFallbackWorkItem = nil
+        if delayNS == 0 {
+            let reason = status.authFailCode != 0 ? "secure_link_failed" : "app_not_ready"
+            eventSink?("tcp_overlay_lower_layer_unavailable", ["reason": reason, "auth_fail_code": status.authFailCode])
+            forceReconnectForUnavailableChannel()
             return
         }
-        let deadlineNS = DispatchTime.now().uptimeNanoseconds + Self.lowerLayerUnavailableFallbackNS
+        let deadlineNS = DispatchTime.now().uptimeNanoseconds + delayNS
         lowerLayerFallbackDeadlineNS = deadlineNS
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
@@ -785,7 +844,7 @@ final class ObstacleBridgeTcpOverlayTransportOwner {
             self.forceReconnectForUnavailableChannel()
         }
         lowerLayerFallbackWorkItem = workItem
-        queue.asyncAfter(deadline: .now() + .nanoseconds(Int(Self.lowerLayerUnavailableFallbackNS)), execute: workItem)
+        queue.asyncAfter(deadline: .now() + .nanoseconds(Int(delayNS)), execute: workItem)
     }
 
     private func forceReconnectForUnavailableChannel() {

--- a/ios/native/ObstacleBridgeShared/ObstacleBridgeUdpOverlayTransportOwner.swift
+++ b/ios/native/ObstacleBridgeShared/ObstacleBridgeUdpOverlayTransportOwner.swift
@@ -547,6 +547,7 @@ final class ObstacleBridgeUdpOverlayTransportOwner {
         }
         let nowNS = monotonicNowNS()
         handleTransportLiveness(nowNS: nowNS)
+        flushDueSecureLinkFramesIfNeeded()
         let snapshot = overlayRuntime.handleControlTimerTick(nowNS: nowNS, sendPortPresent: currentPeerAddress != nil)
         guard snapshot.controlShouldEmit else {
             return
@@ -556,6 +557,23 @@ final class ObstacleBridgeUdpOverlayTransportOwner {
             sendDatagram(control.frame)
         } catch {
             eventSink?("udp_overlay_control_timer_failed", ["error": error.localizedDescription])
+        }
+    }
+
+    private func flushDueSecureLinkFramesIfNeeded() {
+        guard let adapter = overlayLayerTransportAdapter else {
+            return
+        }
+        do {
+            let snapshot = try adapter.pollSecureLinkDueFrames()
+            guard !snapshot.emittedFrames.isEmpty else {
+                return
+            }
+            for frame in snapshot.emittedFrames {
+                sendOverlayTransportPayload(frame)
+            }
+        } catch {
+            eventSink?("udp_overlay_secure_link_due_frames_failed", ["error": error.localizedDescription])
         }
     }
 
@@ -734,13 +752,25 @@ final class ObstacleBridgeUdpOverlayTransportOwner {
         guard let adapter = overlayLayerTransportAdapter,
               let status = adapter.secureLinkStatusSnapshot(),
               status.clientMode,
-              !status.peerConfirmedAuthenticated,
-              secureLinkHandshakePrimed,
-              lastSecureLinkPrimeNS != 0,
-              nowNS >= lastSecureLinkPrimeNS,
-              (nowNS - lastSecureLinkPrimeNS) >= Self.lowerLayerUnavailableFallbackNS
+              !status.peerConfirmedAuthenticated
         else {
             return false
+        }
+        if status.authFailCode != 0 {
+            guard status.recoveryEnabled else {
+                return false
+            }
+            if status.recoveryReconnectSec > 0.0 {
+                return false
+            }
+        } else {
+            guard secureLinkHandshakePrimed,
+                  lastSecureLinkPrimeNS != 0,
+                  nowNS >= lastSecureLinkPrimeNS,
+                  (nowNS - lastSecureLinkPrimeNS) >= Self.lowerLayerUnavailableFallbackNS
+            else {
+                return false
+            }
         }
         let reason: String
         if status.authFailCode != 0 {

--- a/ios/native/ObstacleBridgeShared/ObstacleBridgeWebSocketOverlayTransportOwner.swift
+++ b/ios/native/ObstacleBridgeShared/ObstacleBridgeWebSocketOverlayTransportOwner.swift
@@ -723,10 +723,27 @@ final class ObstacleBridgeWebSocketOverlayTransportOwner: NSObject, URLSessionWe
             lowerLayerFallbackDeadlineNS = nil
             return
         }
-        if lowerLayerFallbackWorkItem != nil {
+        let delayNS: UInt64
+        if status.authFailCode != 0 {
+            guard status.recoveryEnabled, status.recoveryReconnectSec > 0.0 else {
+                lowerLayerFallbackWorkItem?.cancel()
+                lowerLayerFallbackWorkItem = nil
+                lowerLayerFallbackDeadlineNS = nil
+                return
+            }
+            delayNS = UInt64(max(0.0, status.recoveryReconnectSec) * 1_000_000_000.0)
+        } else {
+            delayNS = Self.lowerLayerUnavailableFallbackNS
+        }
+        lowerLayerFallbackWorkItem?.cancel()
+        lowerLayerFallbackWorkItem = nil
+        if delayNS == 0 {
+            let reason = status.authFailCode != 0 ? "secure_link_failed" : "app_not_ready"
+            eventSink?("ws_overlay_lower_layer_unavailable", ["reason": reason, "auth_fail_code": status.authFailCode])
+            forceReconnectForUnavailableChannel()
             return
         }
-        lowerLayerFallbackDeadlineNS = DispatchTime.now().uptimeNanoseconds + Self.lowerLayerUnavailableFallbackNS
+        lowerLayerFallbackDeadlineNS = DispatchTime.now().uptimeNanoseconds + delayNS
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.lowerLayerFallbackWorkItem = nil
@@ -739,7 +756,7 @@ final class ObstacleBridgeWebSocketOverlayTransportOwner: NSObject, URLSessionWe
             self.forceReconnectForUnavailableChannel()
         }
         lowerLayerFallbackWorkItem = workItem
-        queue.asyncAfter(deadline: .now() + .nanoseconds(Int(Self.lowerLayerUnavailableFallbackNS)), execute: workItem)
+        queue.asyncAfter(deadline: .now() + .nanoseconds(Int(delayNS)), execute: workItem)
     }
 
     private func forceReconnectForUnavailableChannel() {
@@ -918,6 +935,7 @@ final class ObstacleBridgeWebSocketOverlayTransportOwner: NSObject, URLSessionWe
 
     private func sendRTTPingAndReschedule(for task: URLSessionWebSocketTask) {
         guard started, overlayConnected, websocketTask === task else { return }
+        flushDueSecureLinkFramesIfNeeded()
         let txNS = DispatchTime.now().uptimeNanoseconds
         do {
             let message = try overlayRuntime.encodeClientPing(txNS: txNS, echoNS: lastPeerPingTxNS)
@@ -936,6 +954,24 @@ final class ObstacleBridgeWebSocketOverlayTransportOwner: NSObject, URLSessionWe
         } catch {
             eventSink?("ws_overlay_control_encode_failed", ["error": error.localizedDescription])
             scheduleNextRTTPing(for: task)
+        }
+    }
+
+    private func flushDueSecureLinkFramesIfNeeded() {
+        guard let adapter = overlayLayerTransportAdapter else {
+            return
+        }
+        do {
+            let snapshot = try adapter.pollSecureLinkDueFrames()
+            guard !snapshot.emittedFrames.isEmpty else {
+                return
+            }
+            for frame in snapshot.emittedFrames {
+                sendRawOverlayWire(frame)
+            }
+            updateLowerLayerFallback()
+        } catch {
+            eventSink?("ws_overlay_secure_link_due_frames_failed", ["error": error.localizedDescription])
         }
     }
 

--- a/ios/tests/test_ios_secure_link_transport_adapter.py
+++ b/ios/tests/test_ios_secure_link_transport_adapter.py
@@ -346,6 +346,383 @@ def test_ios_secure_link_transport_adapter_operator_rekey_completes_and_updates_
     }
 
 
+def test_ios_secure_link_transport_adapter_frame_threshold_rekey_matches_python_semantics(tmp_path: Path) -> None:
+    source_path = tmp_path / "SecureLinkTransportFrameThresholdProbe.swift"
+    binary_path = tmp_path / "secure-link-transport-frame-threshold-probe"
+    source_path.write_text(
+        textwrap.dedent(
+            r"""
+            import Foundation
+
+            enum ProbeError: Error {
+                case badState(String)
+            }
+
+            @main
+            struct SecureLinkTransportFrameThresholdProbe {
+                static func main() throws {
+                    var sessionIDs: [UInt64] = [0x0102030405060708, 0x0102030405060709]
+                    let client = ObstacleBridgeSecureLinkPskTransportAdapter(
+                        runtime: ObstacleBridgeSecureLinkPskRuntime(
+                            clientMode: true,
+                            psk: "shared-psk",
+                            rekeyAfterFrames: 3,
+                            randomBytes: { count in Data(repeating: 0x11, count: count) },
+                            sessionIDProvider: {
+                                if sessionIDs.isEmpty {
+                                    return 0x0102030405060710
+                                }
+                                return sessionIDs.removeFirst()
+                            },
+                            unixTimeProvider: { 1700000004.0 }
+                        )
+                    )
+                    let server = ObstacleBridgeSecureLinkPskTransportAdapter(
+                        runtime: ObstacleBridgeSecureLinkPskRuntime(
+                            clientMode: false,
+                            psk: "shared-psk",
+                            randomBytes: { count in Data(repeating: 0x22, count: count) },
+                            sessionIDProvider: { 0 },
+                            unixTimeProvider: { 1700000005.0 }
+                        )
+                    )
+
+                    let clientHello = try client.handleTransportConnected().emittedFrames.first!
+                    let serverHello = server.handleInboundFrame(clientHello).emittedFrames.first!
+                    let clientProof = client.handleInboundFrame(serverHello).emittedFrames.first!
+                    _ = server.handleInboundFrame(clientProof)
+                    let warmupReply = try server.handleOutboundPayload(Data("warmup".utf8)).emittedFrames.first!
+                    _ = client.handleInboundFrame(warmupReply)
+
+                    for index in 1...2 {
+                        let outbound = try client.handleOutboundPayload(Data("payload-\(index)".utf8))
+                        if outbound.emittedFrames.count != 1 {
+                            throw ProbeError.badState("unexpected rekey before threshold")
+                        }
+                        _ = server.handleInboundFrame(outbound.emittedFrames[0])
+                    }
+
+                    let thresholdSend = try client.handleOutboundPayload(Data("payload-3".utf8))
+                    guard thresholdSend.emittedFrames.count == 2 else {
+                        throw ProbeError.badState("threshold send did not emit data plus rekey hello")
+                    }
+                    guard let dataFrame = thresholdSend.emittedFrames.first,
+                          let rekeyHello = thresholdSend.emittedFrames.dropFirst().first,
+                          ObstacleBridgeSecureLinkPskCodec.parseFrame(rekeyHello)?.slType == ObstacleBridgeSecureLinkPskRuntime.typeRekeyHello
+                    else {
+                        throw ProbeError.badState("missing rekey hello at threshold")
+                    }
+
+                    _ = server.handleInboundFrame(dataFrame)
+                    let rekeyReply = server.handleInboundFrame(rekeyHello).emittedFrames.first!
+                    let rekeyCommit = client.handleInboundFrame(rekeyReply).emittedFrames.first!
+                    let rekeyDone = server.handleInboundFrame(rekeyCommit).emittedFrames.first!
+                    _ = client.handleInboundFrame(rekeyDone)
+
+                    let payload: [String: Any] = [
+                        "client_session_id": String(client.statusSnapshot().sessionID),
+                        "server_session_id": String(server.statusSnapshot().sessionID),
+                        "client_rekeys_completed_total": client.statusSnapshot().rekeysCompletedTotal,
+                        "server_rekeys_completed_total": server.statusSnapshot().rekeysCompletedTotal,
+                        "client_last_rekey_trigger": client.statusSnapshot().lastRekeyTrigger,
+                        "server_last_rekey_trigger": server.statusSnapshot().lastRekeyTrigger,
+                        "client_authenticated_sessions_total": client.statusSnapshot().authenticatedSessionsTotal,
+                        "server_authenticated_sessions_total": server.statusSnapshot().authenticatedSessionsTotal,
+                        "client_last_event": client.statusSnapshot().lastEvent,
+                        "server_last_event": server.statusSnapshot().lastEvent,
+                    ]
+                    let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+                    FileHandle.standardOutput.write(data)
+                }
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    _compile_swift_secure_link_transport_probe(source_path, binary_path)
+    completed = subprocess.run([str(binary_path)], capture_output=True, text=True, check=False, timeout=30)
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"probe failed with exit code {completed.returncode}:\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+        )
+    payload = json.loads(completed.stdout)
+
+    assert payload == {
+        "client_session_id": "72623859790382857",
+        "server_session_id": "72623859790382857",
+        "client_rekeys_completed_total": 1,
+        "server_rekeys_completed_total": 1,
+        "client_last_rekey_trigger": "frame_threshold",
+        "server_last_rekey_trigger": "remote",
+        "client_authenticated_sessions_total": 2,
+        "server_authenticated_sessions_total": 2,
+        "client_last_event": "rekey_completed",
+        "server_last_event": "rekey_completed",
+    }
+
+
+def test_ios_secure_link_transport_adapter_time_threshold_rekey_can_fire_while_idle(tmp_path: Path) -> None:
+    source_path = tmp_path / "SecureLinkTransportTimeThresholdProbe.swift"
+    binary_path = tmp_path / "secure-link-transport-time-threshold-probe"
+    source_path.write_text(
+        textwrap.dedent(
+            r"""
+            import Foundation
+
+            enum ProbeError: Error {
+                case badState(String)
+            }
+
+            @main
+            struct SecureLinkTransportTimeThresholdProbe {
+                static func main() throws {
+                    var monoTime = 100.0
+                    var sessionIDs: [UInt64] = [0x0102030405060708, 0x0102030405060709]
+                    let client = ObstacleBridgeSecureLinkPskTransportAdapter(
+                        runtime: ObstacleBridgeSecureLinkPskRuntime(
+                            clientMode: true,
+                            psk: "shared-psk",
+                            rekeyAfterSeconds: 5.0,
+                            randomBytes: { count in Data(repeating: 0x11, count: count) },
+                            sessionIDProvider: {
+                                if sessionIDs.isEmpty {
+                                    return 0x0102030405060710
+                                }
+                                return sessionIDs.removeFirst()
+                            },
+                            timeProvider: { monoTime },
+                            unixTimeProvider: { 1700000006.0 }
+                        )
+                    )
+                    let server = ObstacleBridgeSecureLinkPskTransportAdapter(
+                        runtime: ObstacleBridgeSecureLinkPskRuntime(
+                            clientMode: false,
+                            psk: "shared-psk",
+                            randomBytes: { count in Data(repeating: 0x22, count: count) },
+                            sessionIDProvider: { 0 },
+                            timeProvider: { monoTime },
+                            unixTimeProvider: { 1700000007.0 }
+                        )
+                    )
+
+                    let clientHello = try client.handleTransportConnected().emittedFrames.first!
+                    let serverHello = server.handleInboundFrame(clientHello).emittedFrames.first!
+                    let clientProof = client.handleInboundFrame(serverHello).emittedFrames.first!
+                    _ = server.handleInboundFrame(clientProof)
+                    let warmupReply = try server.handleOutboundPayload(Data("warmup".utf8)).emittedFrames.first!
+                    _ = client.handleInboundFrame(warmupReply)
+
+                    monoTime += 4.0
+                    if !(try client.pollDueFrames().emittedFrames.isEmpty) {
+                        throw ProbeError.badState("time-based rekey fired too early")
+                    }
+
+                    monoTime += 2.0
+                    let due = try client.pollDueFrames()
+                    guard let rekeyHello = due.emittedFrames.first,
+                          due.emittedFrames.count == 1,
+                          ObstacleBridgeSecureLinkPskCodec.parseFrame(rekeyHello)?.slType == ObstacleBridgeSecureLinkPskRuntime.typeRekeyHello
+                    else {
+                        throw ProbeError.badState("missing time-based rekey hello")
+                    }
+
+                    let rekeyReply = server.handleInboundFrame(rekeyHello).emittedFrames.first!
+                    let rekeyCommit = client.handleInboundFrame(rekeyReply).emittedFrames.first!
+                    let rekeyDone = server.handleInboundFrame(rekeyCommit).emittedFrames.first!
+                    _ = client.handleInboundFrame(rekeyDone)
+
+                    let payload: [String: Any] = [
+                        "client_session_id": String(client.statusSnapshot().sessionID),
+                        "server_session_id": String(server.statusSnapshot().sessionID),
+                        "client_rekeys_completed_total": client.statusSnapshot().rekeysCompletedTotal,
+                        "server_rekeys_completed_total": server.statusSnapshot().rekeysCompletedTotal,
+                        "client_last_rekey_trigger": client.statusSnapshot().lastRekeyTrigger,
+                        "server_last_rekey_trigger": server.statusSnapshot().lastRekeyTrigger,
+                        "client_authenticated_sessions_total": client.statusSnapshot().authenticatedSessionsTotal,
+                        "server_authenticated_sessions_total": server.statusSnapshot().authenticatedSessionsTotal,
+                        "client_last_event": client.statusSnapshot().lastEvent,
+                        "server_last_event": server.statusSnapshot().lastEvent,
+                    ]
+                    let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+                    FileHandle.standardOutput.write(data)
+                }
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    _compile_swift_secure_link_transport_probe(source_path, binary_path)
+    completed = subprocess.run([str(binary_path)], capture_output=True, text=True, check=False, timeout=30)
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"probe failed with exit code {completed.returncode}:\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+        )
+    payload = json.loads(completed.stdout)
+
+    assert payload == {
+        "client_session_id": "72623859790382857",
+        "server_session_id": "72623859790382857",
+        "client_rekeys_completed_total": 1,
+        "server_rekeys_completed_total": 1,
+        "client_last_rekey_trigger": "time_threshold",
+        "server_last_rekey_trigger": "remote",
+        "client_authenticated_sessions_total": 2,
+        "server_authenticated_sessions_total": 2,
+        "client_last_event": "rekey_completed",
+        "server_last_event": "rekey_completed",
+    }
+
+
+def test_ios_secure_link_transport_adapter_retry_and_recovery_policy_matches_python_shape(tmp_path: Path) -> None:
+    source_path = tmp_path / "SecureLinkTransportRetryRecoveryProbe.swift"
+    binary_path = tmp_path / "secure-link-transport-retry-recovery-probe"
+    source_path.write_text(
+        textwrap.dedent(
+            r"""
+            import Foundation
+
+            enum ProbeError: Error {
+                case badState(String)
+            }
+
+            @main
+            struct SecureLinkTransportRetryRecoveryProbe {
+                static func main() throws {
+                    var mono = 100.0
+                    var unix = 2000.0
+
+                    let retryClient = ObstacleBridgeSecureLinkPskTransportAdapter(
+                        runtime: ObstacleBridgeSecureLinkPskRuntime(
+                            clientMode: true,
+                            psk: "shared-psk",
+                            randomBytes: { count in Data(repeating: 0x11, count: count) },
+                            sessionIDProvider: { 0x0102030405060708 },
+                            timeProvider: { mono },
+                            unixTimeProvider: { unix }
+                        ),
+                        retryBackoffInitialMS: 1000,
+                        retryBackoffMaxMS: 5000,
+                        recoverAfterFailure: true,
+                        recoverDelaySeconds: 30.0,
+                        timeProvider: { mono },
+                        unixTimeProvider: { unix }
+                    )
+
+                    let firstHandshake = try retryClient.handleTransportConnected()
+                    guard firstHandshake.emittedFrames.count == 1 else {
+                        throw ProbeError.badState("missing initial client hello")
+                    }
+                    let retryFailure = retryClient.handleInboundFrame(Data([0x00, 0x01, 0x02]))
+                    guard retryFailure.authFailCode == ObstacleBridgeSecureLinkPskRuntime.authFailDecode else {
+                        throw ProbeError.badState("expected decode failure")
+                    }
+                    let retryStatus = retryClient.statusSnapshot()
+                    if retryStatus.retryBackoffSec != 1.0 || retryStatus.nextRetryUnixTs != 2001.0 {
+                        throw ProbeError.badState("retry schedule mismatch")
+                    }
+                    if retryStatus.recoveryReconnectSec != 0.0 || retryStatus.nextRecoveryReconnectUnixTs != nil {
+                        throw ProbeError.badState("unexpected recovery schedule for unauthenticated failure")
+                    }
+
+                    mono = 101.0
+                    unix = 2001.0
+                    let retriedHandshake = try retryClient.pollDueFrames()
+                    guard retriedHandshake.emittedFrames.count == 1 else {
+                        throw ProbeError.badState("expected scheduled retry client hello")
+                    }
+                    let retryStatusAfterPoll = retryClient.statusSnapshot()
+
+                    mono = 300.0
+                    unix = 4000.0
+                    let authClient = ObstacleBridgeSecureLinkPskTransportAdapter(
+                        runtime: ObstacleBridgeSecureLinkPskRuntime(
+                            clientMode: true,
+                            psk: "shared-psk",
+                            randomBytes: { count in Data(repeating: 0x33, count: count) },
+                            sessionIDProvider: { 0x1112131415161718 },
+                            timeProvider: { mono },
+                            unixTimeProvider: { unix }
+                        ),
+                        retryBackoffInitialMS: 1000,
+                        retryBackoffMaxMS: 5000,
+                        recoverAfterFailure: true,
+                        recoverDelaySeconds: 30.0,
+                        timeProvider: { mono },
+                        unixTimeProvider: { unix }
+                    )
+                    let authServer = ObstacleBridgeSecureLinkPskTransportAdapter(
+                        runtime: ObstacleBridgeSecureLinkPskRuntime(
+                            clientMode: false,
+                            psk: "shared-psk",
+                            randomBytes: { count in Data(repeating: 0x44, count: count) },
+                            sessionIDProvider: { 0 },
+                            timeProvider: { mono },
+                            unixTimeProvider: { unix }
+                        )
+                    )
+
+                    let authHello = try authClient.handleTransportConnected().emittedFrames.first!
+                    let authServerHello = authServer.handleInboundFrame(authHello).emittedFrames.first!
+                    let authClientProof = authClient.handleInboundFrame(authServerHello).emittedFrames.first!
+                    _ = authServer.handleInboundFrame(authClientProof)
+                    let warmupReply = try authServer.handleOutboundPayload(Data("warmup".utf8)).emittedFrames.first!
+                    _ = authClient.handleInboundFrame(warmupReply)
+                    if !authClient.statusSnapshot().authenticated {
+                        throw ProbeError.badState("expected authenticated client")
+                    }
+
+                    let recoveryFailure = authClient.handleInboundFrame(Data([0x00, 0x01, 0x02]))
+                    guard recoveryFailure.authFailCode == ObstacleBridgeSecureLinkPskRuntime.authFailDecode else {
+                        throw ProbeError.badState("expected decode failure after authentication")
+                    }
+                    let recoveryStatus = authClient.statusSnapshot()
+                    if recoveryStatus.retryBackoffSec != 0.0 || recoveryStatus.nextRetryUnixTs != nil {
+                        throw ProbeError.badState("authenticated failure should not schedule retry backoff")
+                    }
+                    if recoveryStatus.recoveryReconnectSec != 30.0 || recoveryStatus.nextRecoveryReconnectUnixTs != 4030.0 {
+                        throw ProbeError.badState("recovery reconnect schedule mismatch")
+                    }
+
+                    let payload: [String: Any] = [
+                        "retry_consecutive_failures": retryStatus.consecutiveFailures,
+                        "retry_retry_backoff_sec": retryStatus.retryBackoffSec,
+                        "retry_next_retry_unix_ts": retryStatus.nextRetryUnixTs ?? NSNull(),
+                        "retry_handshake_attempts_total": retryStatusAfterPoll.handshakeAttemptsTotal,
+                        "retry_backoff_after_poll_sec": retryStatusAfterPoll.retryBackoffSec,
+                        "recovery_enabled": recoveryStatus.recoveryEnabled,
+                        "recovery_delay_sec": recoveryStatus.recoveryDelaySec,
+                        "recovery_reconnect_sec": recoveryStatus.recoveryReconnectSec,
+                        "recovery_next_reconnect_unix_ts": recoveryStatus.nextRecoveryReconnectUnixTs ?? NSNull(),
+                    ]
+                    let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+                    FileHandle.standardOutput.write(data)
+                }
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+    _compile_swift_secure_link_transport_probe(source_path, binary_path)
+    completed = subprocess.run([str(binary_path)], capture_output=True, text=True, check=False, timeout=30)
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"probe failed with exit code {completed.returncode}:\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+        )
+    payload = json.loads(completed.stdout)
+
+    assert payload == {
+        "retry_consecutive_failures": 1,
+        "retry_retry_backoff_sec": 1.0,
+        "retry_next_retry_unix_ts": 2001.0,
+        "retry_handshake_attempts_total": 2,
+        "retry_backoff_after_poll_sec": 0.0,
+        "recovery_enabled": True,
+        "recovery_delay_sec": 30.0,
+        "recovery_reconnect_sec": 30.0,
+        "recovery_next_reconnect_unix_ts": 4030.0,
+    }
+
+
 def test_ios_secure_link_transport_adapter_can_prime_handshake_on_transport_connect(tmp_path: Path) -> None:
     source_path = tmp_path / "SecureLinkTransportConnectProbe.swift"
     binary_path = tmp_path / "secure-link-transport-connect-probe"
@@ -461,7 +838,8 @@ def test_ios_secure_link_transport_adapter_reconnect_edge_reprimes_after_authent
                                 }
                                 return clientSessionIDs.removeFirst()
                             }
-                        )
+                        ),
+                        recoverAfterFailure: false
                     )
                     let server = ObstacleBridgeSecureLinkPskTransportAdapter(
                         runtime: ObstacleBridgeSecureLinkPskRuntime(

--- a/ios/tests/test_m3_native_sources.py
+++ b/ios/tests/test_m3_native_sources.py
@@ -105,6 +105,12 @@ def test_ipserver_packet_tunnel_provider_source_exists() -> None:
     assert '"disconnect_reason": snapshot.disconnectReason' in provider
     assert '"disconnect_detail": snapshot.disconnectDetail' in provider
     assert '"throttle": ObstacleBridgeAdminSnapshotSupport.peerThrottleSnapshot(peerID: 1, connectionsSnapshot: connections)' in provider
+    assert 'summary["secure_link_rekey_after_frames"] = rekeyAfterFrames' in provider
+    assert 'summary["secure_link_rekey_after_seconds"] = rekeyAfterSeconds' in provider
+    assert 'summary["secure_link_retry_backoff_initial_ms"] = retryBackoffInitialMS' in provider
+    assert 'summary["secure_link_retry_backoff_max_ms"] = retryBackoffMaxMS' in provider
+    assert 'summary["secure_link_recover_after_failure"] = recoverAfterFailure' in provider
+    assert 'summary["secure_link_recover_delay_seconds"] = recoverDelaySeconds' in provider
     assert "static func peerThrottleSnapshot(peerID: Int, connectionsSnapshot: [String: Any]) -> [String: Any]" in snapshot_support
     assert 'let budgetBytes = Int(Double(prevWindowBytes) * peerThrottleRatio)' in snapshot_support
 
@@ -127,6 +133,12 @@ def test_ipserver_packet_tunnel_provider_source_exists() -> None:
     assert 'schemaItem(key: "proxy_provider_socks5_port", description: "Local SOCKS5 CONNECT proxy listener port."' in runtime_config
     assert 'schemaItem(key: "proxy_provider_http_port", description: "Local HTTP/CONNECT proxy listener port.", defaultValue: 13881)' in runtime_config
     assert 'schemaItem(key: "proxy_provider_socks5_port", description: "Local SOCKS5 CONNECT proxy listener port.", defaultValue: 13882)' in runtime_config
+    assert 'schemaItem(key: "secure_link_rekey_after_frames", description: "Automatically rekey PSK sessions after this many protected data frames. 0 disables frame-triggered rekey.", defaultValue: 0)' in runtime_config
+    assert 'schemaItem(key: "secure_link_rekey_after_seconds", description: "Automatically rekey PSK sessions after this many authenticated seconds. 0 disables time-triggered rekey.", defaultValue: 0.0)' in runtime_config
+    assert 'schemaItem(key: "secure_link_retry_backoff_initial_ms", description: "Initial SecureLink client retry backoff after authentication failure, in milliseconds.", defaultValue: 1000)' in runtime_config
+    assert 'schemaItem(key: "secure_link_retry_backoff_max_ms", description: "Maximum SecureLink client retry backoff after repeated authentication failures, in milliseconds.", defaultValue: 5000)' in runtime_config
+    assert 'schemaItem(key: "secure_link_recover_after_failure", description: "Whether SecureLink client failures should trigger a delayed transport reconnect recovery.", defaultValue: true)' in runtime_config
+    assert 'schemaItem(key: "secure_link_recover_delay_seconds", description: "Seconds to wait before the SecureLink client forces a transport reconnect after persistent failure.", defaultValue: 30.0)' in runtime_config
     assert 'schemaItem(key: "proxy_provider_egress", description: "Proxy egress policy object for outbound connection behavior.", defaultValue: [' in runtime_config
     assert '"mode": "system"' in runtime_config
     assert 'schemaItem(key: "log_proxy_provider", description: "Proxy provider log level override."' in runtime_config
@@ -138,6 +150,12 @@ def test_ipserver_packet_tunnel_provider_source_exists() -> None:
     host_runner = (APP_NATIVE_DIR / "ObstacleBridgeHostRunner.swift").read_text(encoding="utf-8")
     assert 'let egress = (section?["egress"] ?? runtimeConfig["proxy_provider_egress"]) as? [String: Any] ?? [' in host_runner
     assert '"mode": "system"' in host_runner
+    assert 'let rekeyAfterFrames = Self.intValue(from: runtimeConfig["secure_link_rekey_after_frames"]) ?? 0' in host_runner
+    assert 'let rekeyAfterSeconds = Self.doubleValue(from: runtimeConfig["secure_link_rekey_after_seconds"]) ?? 0.0' in host_runner
+    assert 'let retryBackoffInitialMS = Self.intValue(from: runtimeConfig["secure_link_retry_backoff_initial_ms"]) ?? 1000' in host_runner
+    assert 'let retryBackoffMaxMS = Self.intValue(from: runtimeConfig["secure_link_retry_backoff_max_ms"]) ?? 5000' in host_runner
+    assert 'let recoverAfterFailure = Self.boolValue(from: runtimeConfig["secure_link_recover_after_failure"]) ?? true' in host_runner
+    assert 'let recoverDelaySeconds = Self.doubleValue(from: runtimeConfig["secure_link_recover_delay_seconds"]) ?? 30.0' in host_runner
 
 
 def test_native_packet_flow_bridge_source_exists() -> None:


### PR DESCRIPTION
## Summary

This PR brings the Swift PSK SecureLink client closer to Python parity by adding configurable retry/recovery policy, restoring automatic PSK rekey triggers, and exposing the new behavior through the existing iOS/macOS admin status payloads.

## Problem

Swift only supported manual PSK rekey and relied on fixed owner-level reconnect behavior after SecureLink failures. Python already supported three PSK rekey triggers plus SecureLink-specific retry backoff and delayed recovery reconnect policy. On iOS/macOS this left real parity gaps: automatic PSK rekey did not run in idle sessions, SecureLink retry/recovery was not configurable, and the admin surface could not show the same retry/recovery countdowns that Python exposes.

## Changes

- Added Swift PSK rekey configuration for `secure_link_rekey_after_frames` and `secure_link_rekey_after_seconds` in the runtime schema and bootstrap wiring.
- Extended the shared Swift PSK runtime and adapter to support:
  - automatic frame-threshold rekey
  - automatic idle time-threshold rekey
  - client retry backoff after unauthenticated failure
  - delayed recovery reconnect policy after authenticated failure
- Updated TCP, WebSocket, QUIC, and UDP transport owners so due SecureLink frames are flushed while the session is idle and SecureLink auth failures follow the new recovery policy instead of only fixed reconnect timing.
- Enriched Swift admin status payloads with retry/recovery state such as handshake attempts, consecutive failures, retry backoff, and recovery reconnect countdowns.
- Added focused Swift probe coverage and source guards for the new config and runtime behavior.

## Why This Matters

This closes an operational parity gap that made Swift SecureLink harder to tune and harder to debug than Python. The new behavior keeps PSK reconnect handling closer to Python semantics, makes automatic rekey usable without manual intervention, and gives the web admin enough state to explain whether Swift is retrying in-place or waiting for a delayed recovery reconnect.

## Validation

Run the exact commands you used to validate this PR and paste short results.

```bash
./.venv/bin/python -m pytest -q ios/tests/test_ios_secure_link_transport_adapter.py
./.venv/bin/python -m pytest -q ios/tests/test_m3_native_sources.py -k 'ipserver_packet_tunnel_provider_source_exists'
base=$(git rev-parse origin/main) && ./.venv/bin/python scripts/check_requirements_guard.py --base-ref "$base"
base=$(git rev-parse origin/main) && ./.venv/bin/python scripts/check_readme_testing_guard.py --base-ref "$base"
```

Results: `8 passed`; `1 passed, 36 deselected`; `Requirements guard passed.`; `README/traceability guard passed.`

## Reviewer Notes

- Focus review on: the new split between in-place SecureLink retry backoff and delayed transport recovery reconnect.
- Focus review on: transport-owner handling of idle due-frame polling for automatic time-based rekey.
- Focus review on: admin payload parity for retry/recovery state and existing SecureLink counters.
- Suggested reviewers: @ohnoohweh

---

Checklist before merging:

- [x] Tests run locally and CI is expected to pass
- [ ] `docs/REQUIREMENTS.md` updated when behavior/tests changed
- [ ] `README.md` updated when requirement/test set changed
- [ ] `.github/requirements_traceability.yaml` updated when requirement IDs changed
- [ ] Linked to any relevant design/architecture docs in `docs/`
